### PR TITLE
Revert "Add oracle JVM 8"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,6 @@ RUN set -eux; \
     sudo apt-get update; \
     sudo apt-get install zulu7 zulu8 zulu11 zulu13 zulu15;
 
-# Install oracle jvm
-RUN set -eux; \
-    wget -q -O /tmp/oracle-jdk8.tar.gz -c --no-cookies --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" "https://download.oracle.com/otn-pub/java/jdk/8u281-b09/89d678f2be164786b292527658ca1605/jdk-8u281-linux-x64.tar.gz"; \
-    sudo tar xzf /tmp/oracle-jdk8.tar.gz -C /usr/lib/jvm/; \
-    sudo mv /usr/lib/jvm/jdk1.8.0_281 /usr/lib/jvm/oracle8;
-
 RUN set -eux; \
     JAVA_VERSION=1.8.0_sr6fp15; \
     SUM='1770fc44e0061a72ab9cfc47fb9a1934b17581fee77a3cc32e83b4bee0084256'; \
@@ -85,7 +79,5 @@ ENV JAVA_ZULU8_HOME=/usr/lib/jvm/zulu8
 ENV JAVA_ZULU11_HOME=/usr/lib/jvm/zulu11
 ENV JAVA_ZULU13_HOME=/usr/lib/jvm/zulu13
 ENV JAVA_ZULU15_HOME=/usr/lib/jvm/zulu15
-
-ENV JAVA_ORACLE8_HOME=/usr/lib/jvm/oracle8
 
 ENV JAVA_HOME=${JAVA_8_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ RUN set -eux; \
     sudo apt-get install zulu7 zulu8 zulu11 zulu13 zulu15;
 
 RUN set -eux; \
-    JAVA_VERSION=1.8.0_sr6fp15; \
-    SUM='1770fc44e0061a72ab9cfc47fb9a1934b17581fee77a3cc32e83b4bee0084256'; \
+    JAVA_VERSION=1.8.0_sr6fp30; \
+    SUM='afd31dea9c65fdfef664ac93140115f7c0746445bbe24fc7c62891236d28689d'; \
     YML_FILE='sdk/linux/x86_64/index.yml'; \
-    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
+    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta"; \
     wget -q -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
     JAVA_URL=$(sed -n '/^'${JAVA_VERSION}:'/{n;s/\s*uri:\s//p}'< /tmp/index.yml); \
     wget -q -O /tmp/ibm-java.bin ${JAVA_URL}; \


### PR DESCRIPTION
Reverts DataDog/dd-trace-java-docker-build#27

That build is not available anymore and now seems to require a login.