### PR TITLE
Change datadog-ci to experimental branch for logs from junitxml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,8 @@ RUN set -eux; \
     pip3 install awscli;
 
 # Install datadog-ci
-RUN set -eux; \
-    sudo apt install nodejs npm; \
-    sudo npm install -g @datadog/datadog-ci@0.13.6-alpha;
+RUN sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v1.3.0-alpha/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" \
+    && sudo chmod +x /usr/local/bin/datadog-ci
 
 RUN sudo rm -rf /tmp/..?* /tmp/.[!.]* /tmp/*
 


### PR DESCRIPTION
This is a temporary switch to install from a prerelease so we can test https://github.com/DataDog/datadog-ci/pull/510
I'm also switching to standalone distribution so that installing node/npm is not needed anymore.

This is a new feature for junitxml imports in CI Visibility where we also send texts from `<system-out>` and `<system-err>` to the logs product. This has additional cost so a flag to opt-in is required but it's not available in a standard release of datadog-ci yet.

We want this because the exports from dd-trace-java are the ones that we've seen the biggest load with and we do not want to make the flag and docs public to customers until we've ensured reliability with dogfooding.