### PR TITLE
feat: Add vulnerability scanner

### DIFF
--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -1,0 +1,43 @@
+name: Vulnerability check
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '10 2 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  vuln-check:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+#      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Run Trivy scanner
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build docker image from Dockerfile
+        run: |
+          docker build -t dd-trace-java-docker-build:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: 'dd-trace-java-docker-build:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Add Trivy vulnerability scanner worflow.

It will run daily, on `master` commits, and on PR aiming `master` branch.
Results are gathered in the GitHub security tab, through the code scanning feature.

Here is the result of this behavior on my personal fork:
![Screenshot 2022-12-02 at 14 44 32](https://user-images.githubusercontent.com/1766222/205306513-bb3365a4-ce80-4360-a83a-5c3e50ed90df.png)
![Screenshot 2022-12-02 at 14 45 22](https://user-images.githubusercontent.com/1766222/205306649-0f75af33-24fb-429a-9172-beffcafcc89b.png)
