### PR TITLE
Create per-JDK images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # 2.4.1
       - name: Build images
         run: DOCKER_BUILDKIT=1 ./build
+      - name: Login to ghcr.io
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # 2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Test images
         run: ./build --test
       - name: Push images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # 2.4.1
       - name: Build images
-        run: ./build
+        run: DOCKER_BUILDKIT=1 ./build
       - name: Test images
         run: ./build --test
       - name: Push images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # 3.3.0
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
-        with:
-          version: v0.9.1 # https://github.com/docker/buildx/issues/1533
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # 2.4.1
       - name: Build images
         run: ./build
       - name: Test images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # 2.4.1
-      - name: Build images
-        run: DOCKER_BUILDKIT=1 ./build
       - name: Login to ghcr.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # 2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build images
+        run: DOCKER_BUILDKIT=1 ./build
       - name: Test images
         run: ./build --test
       - name: Push images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: "Build"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+        with:
+          fetch-depth: 0
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # 2.0.0
+        with:
+          version: v0.9.1 # https://github.com/docker/buildx/issues/1533
+      - name: Build images
+        run: ./build
+      - name: Test images
+        run: ./build --test
+      - name: Push images
+        run: echo "TBD"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Test images
         run: ./build --test
       - name: Push images
-        run: echo "TBD"
+        run: ./build --push
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # 3.3.0
-        with:
-          fetch-depth: 0
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # 2.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN sudo rm -rf \
     /usr/lib/jvm/*/sample \
     /usr/lib/jvm/graalvm*/lib/installer
 
-FROM cimg/base:edge-22.04 AS base_builder
+FROM scratch AS base_builder
 
 COPY --from=builder /usr/lib/jvm/8 /usr/lib/jvm/8
 COPY --from=builder /usr/lib/jvm/11 /usr/lib/jvm/11

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ RUN gu install native-image
 FROM ghcr.io/graalvm/graalvm-ce:ol8-java17-22 AS graalvm-native-image-jdk17
 RUN gu install native-image
 
-# CircleCI Base Image with Ubuntu 22.04.3 LTS
+# Intermediate image used to prune cruft from JDKs and squash them all.
 FROM cimg/base:edge-22.04 AS builder
 
-COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/openjdk8
-COPY --from=eclipse-temurin:11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/openjdk11
-COPY --from=eclipse-temurin:17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/openjdk17
+COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
+COPY --from=eclipse-temurin:11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/11
+COPY --from=eclipse-temurin:17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/17
 
 COPY --from=azul/zulu-openjdk:7 /usr/lib/jvm/zulu7 /usr/lib/jvm/zulu7
 COPY --from=azul/zulu-openjdk:8 /usr/lib/jvm/zulu8 /usr/lib/jvm/zulu8
@@ -22,8 +22,8 @@ COPY --from=ibm-semeru-runtimes:open-8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/
 COPY --from=ibm-semeru-runtimes:open-11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/semeru11
 COPY --from=ibm-semeru-runtimes:open-17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/semeru17
 
-COPY --from=graalvm-native-image-jdk11 /opt/graalvm-ce-java11-22* /usr/lib/jvm/graalvm22-jdk11
-COPY --from=graalvm-native-image-jdk17 /opt/graalvm-ce-java17-22* /usr/lib/jvm/graalvm22-jdk17
+COPY --from=graalvm-native-image-jdk11 /opt/graalvm-ce-java11-22* /usr/lib/jvm/graalvm11
+COPY --from=graalvm-native-image-jdk17 /opt/graalvm-ce-java17-22* /usr/lib/jvm/graalvm17
 
 RUN sudo apt-get -y update && sudo apt-get -y install curl
 # See: https://gist.github.com/wavezhang/ba8425f24a968ec9b2a8619d7c2d86a6
@@ -31,6 +31,7 @@ RUN set -eux; \
     sudo mkdir -p /usr/lib/jvm/oracle8; \
     curl -L --fail "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=246284_165374ff4ea84ef0bbd821706e29b123" | sudo tar -xvzf - -C /usr/lib/jvm/oracle8 --strip-components 1
 
+# Remove cruft from JDKs that is not used in the build process.
 RUN sudo rm -rf \
     /usr/lib/jvm/*/man \
     /usr/lib/jvm/*/lib/src.zip \
@@ -38,9 +39,17 @@ RUN sudo rm -rf \
     /usr/lib/jvm/*/sample \
     /usr/lib/jvm/graalvm*/lib/installer
 
-FROM cimg/base:edge-22.04
+FROM cimg/base:edge-22.04 AS base_builder
 
-COPY --from=builder /usr/lib/jvm /usr/lib/jvm
+COPY --from=builder /usr/lib/jvm/8 /usr/lib/jvm/8
+COPY --from=builder /usr/lib/jvm/11 /usr/lib/jvm/11
+COPY --from=builder /usr/lib/jvm/17 /usr/lib/jvm/17
+
+# Base image with minimunm requirenents to build the project.
+# Based on CircleCI Base Image with Ubuntu 22.04.3 LTS, present in most runners.
+FROM cimg/base:edge-22.04 AS base
+
+COPY --from=base_builder /usr/lib/jvm /usr/lib/jvm
 
 COPY autoforward.py /usr/local/bin/autoforward
 
@@ -60,7 +69,6 @@ RUN set -eux; \
     sudo chmod +x /usr/local/bin/datadog-ci;\
     sudo rm -rf /tmp/..?* /tmp/.[!.]* /tmp/*;
 
-
 # IBM specific env variables
 ENV IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
 
@@ -69,10 +77,30 @@ ENV JAVA_DEBIAN_VERSION=unused
 ENV JAVA_VERSION=unused
 
 # Setup environment variables to point to all jvms we have
+ENV JAVA_8_HOME=/usr/lib/jvm/8
+ENV JAVA_11_HOME=/usr/lib/jvm/11
+ENV JAVA_17_HOME=/usr/lib/jvm/17
+
+ENV JAVA_HOME=${JAVA_8_HOME}
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+# Full image for debugging, contains all JDKs.
+FROM base AS full
+
+COPY --from=builder \
+    /usr/lib/jvm/zulu7 \
+    /usr/lib/jvm/zulu8 \
+    /usr/lib/jvm/zulu11 \
+    /usr/lib/jvm/oracle8 \
+    /usr/lib/jvm/ibm8 \
+    /usr/lib/jvm/semeru8 \
+    /usr/lib/jvm/semeru11 \
+    /usr/lib/jvm/semeru17 \
+    /usr/lib/jvm/graalvm11 \
+    /usr/lib/jvm/graalvm17 \
+    /usr/lib/jvm/
+
 ENV JAVA_7_HOME=/usr/lib/jvm/zulu7
-ENV JAVA_8_HOME=/usr/lib/jvm/openjdk8
-ENV JAVA_11_HOME=/usr/lib/jvm/openjdk11
-ENV JAVA_17_HOME=/usr/lib/jvm/openjdk17
 
 ENV JAVA_ZULU7_HOME=/usr/lib/jvm/zulu7
 ENV JAVA_ZULU8_HOME=/usr/lib/jvm/zulu8
@@ -89,8 +117,13 @@ ENV JAVA_SEMERU8_HOME=/usr/lib/jvm/semeru8
 ENV JAVA_SEMERU11_HOME=/usr/lib/jvm/semeru11
 ENV JAVA_SEMERU17_HOME=/usr/lib/jvm/semeru17
 
-ENV JAVA_GRAALVM11_HOME=/usr/lib/jvm/graalvm22-jdk11
-ENV JAVA_GRAALVM17_HOME=/usr/lib/jvm/graalvm22-jdk17
+ENV JAVA_GRAALVM11_HOME=/usr/lib/jvm/graalvm11
+ENV JAVA_GRAALVM17_HOME=/usr/lib/jvm/graalvm17
 
-ENV JAVA_HOME=${JAVA_8_HOME}
-ENV PATH=${JAVA_HOME}/bin:${PATH}
+FROM base AS variant
+ARG VARIANT_LOWER
+ARG VARIANT_UPPER
+
+COPY --from=builder /usr/lib/jvm/${VARIANT_LOWER} /usr/lib/jvm/${VARIANT_LOWER}
+ENV JAVA_${VARIANT_UPPER}_HOME=/usr/lib/jvm/${VARIANT_LOWER}
+ENV JAVA_${VARIANT_LOWER}_HOME=/usr/lib/jvm/${VARIANT_LOWER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ COPY --from=all-jdk /usr/lib/jvm/17 /usr/lib/jvm/17
 # Based on CircleCI Base Image with Ubuntu 22.04.3 LTS, present in most runners.
 FROM cimg/base:edge-22.04 AS base
 
+# https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
+LABEL org.opencontainers.image.source=https://github.com/DataDog/dd-trace-java-docker-build
+
 COPY --from=default-jdk /usr/lib/jvm /usr/lib/jvm
 
 COPY autoforward.py /usr/local/bin/autoforward

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
 COPY --from=eclipse-temurin:11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/11
 COPY --from=eclipse-temurin:17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/17
 
-COPY --from=azul/zulu-openjdk:7 /usr/lib/jvm/zulu7 /usr/lib/jvm/zulu7
+COPY --from=azul/zulu-openjdk:7 /usr/lib/jvm/zulu7 /usr/lib/jvm/7
 COPY --from=azul/zulu-openjdk:8 /usr/lib/jvm/zulu8 /usr/lib/jvm/zulu8
 COPY --from=azul/zulu-openjdk:11 /usr/lib/jvm/zulu11 /usr/lib/jvm/zulu11
 
@@ -89,7 +89,7 @@ ENV PATH=${JAVA_HOME}/bin:${PATH}
 # Full image for debugging, contains all JDKs.
 FROM base AS full
 
-COPY --from=all-jdk /usr/lib/jvm/zulu7 /usr/lib/jvm/zulu7
+COPY --from=all-jdk /usr/lib/jvm/7 /usr/lib/jvm/7
 COPY --from=all-jdk /usr/lib/jvm/zulu8 /usr/lib/jvm/zulu8
 COPY --from=all-jdk /usr/lib/jvm/zulu11 /usr/lib/jvm/zulu11
 COPY --from=all-jdk /usr/lib/jvm/oracle8 /usr/lib/jvm/oracle8
@@ -100,9 +100,9 @@ COPY --from=all-jdk /usr/lib/jvm/semeru17 /usr/lib/jvm/semeru17
 COPY --from=all-jdk /usr/lib/jvm/graalvm11 /usr/lib/jvm/graalvm11
 COPY --from=all-jdk /usr/lib/jvm/graalvm17 /usr/lib/jvm/graalvm17
 
-ENV JAVA_7_HOME=/usr/lib/jvm/zulu7
+ENV JAVA_7_HOME=/usr/lib/jvm/7
 
-ENV JAVA_ZULU7_HOME=/usr/lib/jvm/zulu7
+ENV JAVA_ZULU7_HOME=/usr/lib/jvm/7
 ENV JAVA_ZULU8_HOME=/usr/lib/jvm/zulu8
 ENV JAVA_ZULU11_HOME=/usr/lib/jvm/zulu11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,18 +87,16 @@ ENV PATH=${JAVA_HOME}/bin:${PATH}
 # Full image for debugging, contains all JDKs.
 FROM base AS full
 
-COPY --from=builder \
-    /usr/lib/jvm/zulu7 \
-    /usr/lib/jvm/zulu8 \
-    /usr/lib/jvm/zulu11 \
-    /usr/lib/jvm/oracle8 \
-    /usr/lib/jvm/ibm8 \
-    /usr/lib/jvm/semeru8 \
-    /usr/lib/jvm/semeru11 \
-    /usr/lib/jvm/semeru17 \
-    /usr/lib/jvm/graalvm11 \
-    /usr/lib/jvm/graalvm17 \
-    /usr/lib/jvm/
+COPY --from=builder /usr/lib/jvm/zulu7 /usr/lib/jvm/zulu7
+COPY --from=builder /usr/lib/jvm/zulu8 /usr/lib/jvm/zulu8
+COPY --from=builder /usr/lib/jvm/zulu11 /usr/lib/jvm/zulu11
+COPY --from=builder /usr/lib/jvm/oracle8 /usr/lib/jvm/oracle8
+COPY --from=builder /usr/lib/jvm/ibm8 /usr/lib/jvm/ibm8
+COPY --from=builder /usr/lib/jvm/semeru8 /usr/lib/jvm/semeru8
+COPY --from=builder /usr/lib/jvm/semeru11 /usr/lib/jvm/semeru11
+COPY --from=builder /usr/lib/jvm/semeru17 /usr/lib/jvm/semeru17
+COPY --from=builder /usr/lib/jvm/graalvm11 /usr/lib/jvm/graalvm11
+COPY --from=builder /usr/lib/jvm/graalvm17 /usr/lib/jvm/graalvm17
 
 ENV JAVA_7_HOME=/usr/lib/jvm/zulu7
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,14 @@ ENV JAVA_17_HOME=/usr/lib/jvm/17
 ENV JAVA_HOME=${JAVA_8_HOME}
 ENV PATH=${JAVA_HOME}/bin:${PATH}
 
+FROM base AS variant
+ARG VARIANT_LOWER
+ARG VARIANT_UPPER
+
+COPY --from=all-jdk /usr/lib/jvm/${VARIANT_LOWER} /usr/lib/jvm/${VARIANT_LOWER}
+ENV JAVA_${VARIANT_UPPER}_HOME=/usr/lib/jvm/${VARIANT_LOWER}
+ENV JAVA_${VARIANT_LOWER}_HOME=/usr/lib/jvm/${VARIANT_LOWER}
+
 # Full image for debugging, contains all JDKs.
 FROM base AS full
 
@@ -119,11 +127,3 @@ ENV JAVA_SEMERU17_HOME=/usr/lib/jvm/semeru17
 
 ENV JAVA_GRAALVM11_HOME=/usr/lib/jvm/graalvm11
 ENV JAVA_GRAALVM17_HOME=/usr/lib/jvm/graalvm17
-
-FROM base AS variant
-ARG VARIANT_LOWER
-ARG VARIANT_UPPER
-
-COPY --from=all-jdk /usr/lib/jvm/${VARIANT_LOWER} /usr/lib/jvm/${VARIANT_LOWER}
-ENV JAVA_${VARIANT_UPPER}_HOME=/usr/lib/jvm/${VARIANT_LOWER}
-ENV JAVA_${VARIANT_LOWER}_HOME=/usr/lib/jvm/${VARIANT_LOWER}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+# dd-trace-java-docker-build
+
+Docker images for continuous integration jobs at [dd-trace-java](https://github.com/datadog/dd-trace-java).
+

--- a/build
+++ b/build
@@ -6,7 +6,7 @@ readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 readonly BASE_VARIANTS=(8 11 17)
 
 readonly VARIANTS=(
-    zulu7
+    7
     zulu8
     zulu11
     oracle8

--- a/build
+++ b/build
@@ -18,7 +18,7 @@ readonly VARIANTS=(
     graalvm17
 )
 
-readonly GIT_BRANCH="$(git branch --show-current)"
+readonly GIT_BRANCH="${GITHUB_REF_NAME:-$(git branch --show-current)}"
 if [[ ${GIT_BRANCH} = master ]]; then
     TAG_PREFIX=""
 else

--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-readonly IMAGE_NAME="datadog/dd-trace-java-docker-build"
+readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
 readonly BASE_VARIANTS=(8 11 17)
 
@@ -127,7 +127,12 @@ function do_inner_test() {
 }
 
 function do_push() {
-    :
+    local tag
+    for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
+        tag="${tag,,}"
+        tag="$(image_name "${tag}")"
+        docker push "$tag"
+    done
 }
 
 if [[ -z ${1:-} ]]; then

--- a/build
+++ b/build
@@ -33,13 +33,13 @@ function image_name() {
 function do_build() {
     docker build \
         --target base \
-        --tag ${IMAGE_NAME}:${TAG_PREFIX}base .
+        --tag "$(image_name base)" .
     docker build \
         --target full \
-        --tag ${IMAGE_NAME}:${TAG_PREFIX}latest .
+        --tag "$(image_name latest)" .
     for variant in "${BASE_VARIANTS[@]}"; do
         variant_lower="$(echo -n ${variant} | tr '[:upper:]' '[:lower:]')"
-        docker tag ${IMAGE_NAME}:${TAG_PREFIX}base ${IMAGE_NAME}:${TAG_PREFIX}${variant_lower}
+        docker tag "$(image_name base)" "$(image_name "${variant_lower}")"
     done
     for variant in "${VARIANTS[@]}"; do
         variant_upper="$(echo -n ${variant} | tr '[:lower:]' '[:upper:]')"
@@ -48,7 +48,7 @@ function do_build() {
             --build-arg VARIANT_UPPER=${variant_upper} \
             --build-arg VARIANT_LOWER=${variant_lower} \
             --target variant \
-            --tag ${IMAGE_NAME}:${TAG_PREFIX}${variant_lower} .
+            --tag "$(image_name "${variant_lower}")" .
     done
 }
 

--- a/build
+++ b/build
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -eu
+
+readonly IMAGE_NAME="datadog/dd-trace-java-docker-build"
+
+readonly BASE_VARIANTS=(8 11 17)
+
+readonly VARIANTS=(
+    zulu7
+    zulu8
+    zulu11
+    oracle8
+    ibm8
+    semeru8
+    semeru11
+    semeru17
+    graalvm11
+    graalvm17
+)
+
+readonly GIT_BRANCH="$(git branch --show-current)"
+if [[ ${GIT_BRANCH} = master ]]; then
+    TAG_PREFIX=""
+else
+    TAG_PREFIX="$(echo -n ${GIT_BRANCH} | sed -e 's~/~_~g' | tr '[:upper:]' '[:lower:]')-"
+fi
+
+function image_name() {
+    local variant="${1}"
+    echo -n "${IMAGE_NAME}:${TAG_PREFIX}${variant}"
+}
+
+function do_build() {
+    docker build \
+        --target base \
+        --tag ${IMAGE_NAME}:${TAG_PREFIX}base .
+    docker build \
+        --target full \
+        --tag ${IMAGE_NAME}:${TAG_PREFIX}latest .
+    for variant in "${BASE_VARIANTS[@]}"; do
+        variant_lower="$(echo -n ${variant} | tr '[:upper:]' '[:lower:]')"
+        docker tag ${IMAGE_NAME}:${TAG_PREFIX}base ${IMAGE_NAME}:${TAG_PREFIX}${variant_lower}
+    done
+    for variant in "${VARIANTS[@]}"; do
+        variant_upper="$(echo -n ${variant} | tr '[:lower:]' '[:upper:]')"
+        variant_lower="$(echo -n ${variant} | tr '[:upper:]' '[:lower:]')"
+        docker build \
+            --build-arg VARIANT_UPPER=${variant_upper} \
+            --build-arg VARIANT_LOWER=${variant_lower} \
+            --target variant \
+            --tag ${IMAGE_NAME}:${TAG_PREFIX}${variant_lower} .
+    done
+}
+
+function list_layers() {
+    local image="${1}"
+    docker inspect "${image}" | jq -r '.[].RootFS.Layers[]'
+}
+
+function shares_layers() {
+    local base="${1}"
+    local other="${2}"
+    mapfile -t base_layers < <(list_layers "${base}")
+    mapfile -t other_layers < <(list_layers "${base}")
+    declare -A other_map
+    for ol in "${other_layers[@]}"; do
+        other_map[$ol]=true
+    done
+    for bl in "${base_layers[@]}"; do
+        if [[ ${other_map[$bl]} != true ]]; then
+            echo "Layer $bl from $base not found in $other"
+            return 1
+        fi
+    done
+}
+
+function do_test() {
+    local image_base image_variant
+    image_base="$(image_name base)"
+    mapfile -t base_layers < <(list_layers "${image_base}")
+    for variant in "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
+        image_variant="$(image_name "${variant}")"
+        echo "Checking shared layers for ${image_variant}..."
+        mapfile -t other_layers < <(list_layers "${image_variant}")
+        declare -A other_map
+        for ol in "${other_layers[@]}"; do
+            other_map[$ol]=true
+        done
+        for bl in "${base_layers[@]}"; do
+            if [[ ${other_map[$bl]:-} != true ]]; then
+                echo "Layer $bl from $image_base not found in $image_variant"
+                return 1
+            fi
+        done
+    done
+
+    for variant in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
+        image_variant="$(image_name "${variant}")"
+        echo "Running smoke tests for ${image_variant}..."
+        docker run -u "$(id -u):$(id -g)" -w /work -v "$(pwd):/work" --rm "${image_variant}" /work/build --inner-test "${variant}"
+    done
+}
+
+function do_inner_test() {
+    local variant="${1}"
+    variant_lower="$(echo -n "${variant}" | tr '[:upper:]' '[:lower:]')"
+    variant_upper="$(echo -n "${variant}" | tr '[:lower:]' '[:upper:]')"
+    set -x
+    $JAVA_HOME/bin/java -version
+    $JAVA_8_HOME/bin/java -version
+    $JAVA_11_HOME/bin/java -version
+    $JAVA_17_HOME/bin/java -version
+    if [[ $variant != base && $variant != latest ]]; then
+        env_lower="JAVA_${variant_lower}_HOME"
+        env_upper="JAVA_${variant_upper}_HOME"
+        ${!env_lower}/bin/java -version
+        ${!env_upper}/bin/java -version
+    fi
+}
+
+function do_push() {
+    :
+}
+
+if [[ -z ${1:-} ]]; then
+    do_build
+elif [[ ${1} = "--test" ]]; then
+    do_test
+elif [[ ${1} = "--inner-test" ]]; then
+    shift
+    do_inner_test "$@"
+elif [[ ${1} = "--push" ]]; then
+    do_push
+fi

--- a/build
+++ b/build
@@ -18,11 +18,19 @@ readonly VARIANTS=(
     graalvm17
 )
 
+# Get a TAG_PREFIX for every built image. Resulting images will be tagged as
+# ${TAG_PREFIX}${variant}, where ${variant} is base, latest or a JVM name.
+# ${TAG_PREFIX} is empty for the master branch, and it is a sanitized version
+# of the git branch otherwise. Sanitization is a conversion to lowercase, and
+# replacing all slashes with underscores, which is the same sanitization Docker
+# Hub does for their own builds.
 readonly GIT_BRANCH="${GITHUB_REF_NAME:-$(git branch --show-current)}"
 if [[ ${GIT_BRANCH} = master ]]; then
     TAG_PREFIX=""
 else
-    TAG_PREFIX="$(echo -n ${GIT_BRANCH} | sed -e 's~/~_~g' | tr '[:upper:]' '[:lower:]')-"
+    TAG_PREFIX="${GIT_BRANCH}-"
+    TAG_PREFIX="${TAG_PREFIX,,}"
+    TAG_PREFIX="${TAG_PREFIX//\//_}"
 fi
 
 function image_name() {
@@ -38,15 +46,15 @@ function do_build() {
         --target full \
         --tag "$(image_name latest)" .
     for variant in "${BASE_VARIANTS[@]}"; do
-        variant_lower="$(echo -n ${variant} | tr '[:upper:]' '[:lower:]')"
+        variant_lower="${variant,,}"
         docker tag "$(image_name base)" "$(image_name "${variant_lower}")"
     done
     for variant in "${VARIANTS[@]}"; do
-        variant_upper="$(echo -n ${variant} | tr '[:lower:]' '[:upper:]')"
-        variant_lower="$(echo -n ${variant} | tr '[:upper:]' '[:lower:]')"
+        variant_upper="${variant^^}"
+        variant_lower="${variant,,}"
         docker build \
-            --build-arg VARIANT_UPPER=${variant_upper} \
-            --build-arg VARIANT_LOWER=${variant_lower} \
+            --build-arg "VARIANT_UPPER=${variant_upper}" \
+            --build-arg "VARIANT_LOWER=${variant_lower}" \
             --target variant \
             --tag "$(image_name "${variant_lower}")" .
     done
@@ -103,18 +111,18 @@ function do_test() {
 
 function do_inner_test() {
     local variant="${1}"
-    variant_lower="$(echo -n "${variant}" | tr '[:upper:]' '[:lower:]')"
-    variant_upper="$(echo -n "${variant}" | tr '[:lower:]' '[:upper:]')"
+    variant_lower="${variant,,}"
+    variant_upper="${variant^^}"
     set -x
-    $JAVA_HOME/bin/java -version
-    $JAVA_8_HOME/bin/java -version
-    $JAVA_11_HOME/bin/java -version
-    $JAVA_17_HOME/bin/java -version
+    "$JAVA_HOME/bin/java" -version
+    "$JAVA_8_HOME/bin/java" -version
+    "$JAVA_11_HOME/bin/java" -version
+    "$JAVA_17_HOME/bin/java" -version
     if [[ $variant != base && $variant != latest ]]; then
         env_lower="JAVA_${variant_lower}_HOME"
         env_upper="JAVA_${variant_upper}_HOME"
-        ${!env_lower}/bin/java -version
-        ${!env_upper}/bin/java -version
+        "${!env_lower}/bin/java" -version
+        "${!env_upper}/bin/java" -version
     fi
 }
 


### PR DESCRIPTION
## Description

Create per-JDK images:

* `latest` for the default image, equivalent to the old one: all JDKs used in tests together. From now on, this will be meant only convenience in development, and not used in CI.
* `base` an image with the JDKs required to build the project (OpenJDK 8, 11, 17).
* An image per variant (`8`, `11`, `17`, `zulu8`, etc), these contain the JDKs in the base image, plus one variant for specific jobs.

This will save time when fetching images in CI, which currently takes about 40 seconds per job.

A GitHub Actions workflow is added to build the images and push them to GitHub Packages (ghcr.io).

**This image is now at `ghcr.io/datadog/dd-trace-java-docker-build:latest`!**

## Additional notes

We can follow up this PR with:

* [ ] Disabling automatic builds at Docker Hub for this image.

The CI pipeline with the new images has been tested here: https://github.com/DataDog/dd-trace-java/pull/4877

