### PR TITLE
Add documentation and force amd64 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@
 
 Docker images for continuous integration jobs at [dd-trace-java](https://github.com/datadog/dd-trace-java).
 
+## Usage
+
+Pre-built images are available in [GitHub Container Registry](https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build).
+
+Image variants are available on a per JDK basis:
+- The `base` variant, and its aliases `8`, `11`, `17`, contains the base Eclipse Temurin JDK 8, 11 and 17 versions,
+- The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm11` and `graalvm17` variants all contain the base JDKs in addition to their specific JDK from their name,
+- The `latest` variant contains the base JDKs and all the above specific JDKs.
+
+## Development
+
+To build all the Docker images:
+
+```bash
+./build.sh
+```
+
+And then check the built images:
+
+```bash
+./build.sh --test
+```

--- a/build
+++ b/build
@@ -40,9 +40,11 @@ function image_name() {
 
 function do_build() {
     docker build \
+        --platform linux/amd64 \
         --target base \
         --tag "$(image_name base)" .
     docker build \
+        --platform linux/amd64 \
         --target full \
         --tag "$(image_name latest)" .
     for variant in "${BASE_VARIANTS[@]}"; do
@@ -55,6 +57,7 @@ function do_build() {
         docker build \
             --build-arg "VARIANT_UPPER=${variant_upper}" \
             --build-arg "VARIANT_LOWER=${variant_lower}" \
+            --platform linux/amd64 \
             --target variant \
             --tag "$(image_name "${variant_lower}")" .
     done


### PR DESCRIPTION
The images will be built for amd64 as one of the JDK (ibmjava:8) is not available for arm64.