### PR TITLE
Add cron and manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    # Tuesday at 10. One day after the CircleCI scheduled upddate
+    # See: https://github.com/CircleCI-Public/cimg-base/blob/main/.circleci/schedule.json
+    - cron: '0 10 * * 2' 
+  workflow_dispatch:
+
 jobs:
   build_and_push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add two triggers for CI:

- Schedule cron: One day after CircleCI base image scheduled update
- Manual: To trigger build at need

The goal is to have regular update of the base image to bundle the latest security fixes from base image as soon as possible.  