### PR TITLE
Improve image vuln scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_push:
+  build_push_and_check:
+    name: Build docker image, publish it and run vuln scanner against it
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      packages: write # for image publication to GitHub Packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -28,9 +33,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build images
+        id: build
         run: DOCKER_BUILDKIT=1 ./build
       - name: Test images
         run: ./build --test
       - name: Push images
         run: ./build --push
-
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0
+        with:
+          image-ref: '${{ steps.build.outputs.LATEST_IMAGE_TAG }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -1,4 +1,4 @@
-name: Vulnerability check
+name: Daily vulnerability check
 
 on:
   push:
@@ -24,10 +24,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      #- name: Build docker image from Dockerfile
-      #  run: |
-      #    docker build -t dd-trace-java-docker-build:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0

--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -7,7 +7,8 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
   schedule:
-    - cron: '10 2 * * 0'
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -29,15 +30,15 @@ jobs:
           docker build -t dd-trace-java-docker-build:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # v0.8.0
+        uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0
         with:
           image-ref: 'dd-trace-java-docker-build:${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
+        if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -25,14 +25,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Build docker image from Dockerfile
-        run: |
-          docker build -t dd-trace-java-docker-build:${{ github.sha }} .
+      #- name: Build docker image from Dockerfile
+      #  run: |
+      #    docker build -t dd-trace-java-docker-build:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0
         with:
-          image-ref: 'dd-trace-java-docker-build:${{ github.sha }}'
+          image-ref: 'ghcr.io/datadog/dd-trace-java-docker-build:latest'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/build
+++ b/build
@@ -47,6 +47,7 @@ function do_build() {
         --platform linux/amd64 \
         --target full \
         --tag "$(image_name latest)" .
+    echo "LATEST_IMAGE_TAG=$(image_name latest)" >> $GITHUB_OUTPUT
     for variant in "${BASE_VARIANTS[@]}"; do
         variant_lower="${variant,,}"
         docker tag "$(image_name base)" "$(image_name "${variant_lower}")"


### PR DESCRIPTION
* Scan the CI built image to check vuln as early as possible (for PR as new main build),
* Scan the published image daily to get earlier notifications,
* Update to latest trivy scanner action to remove deprecation notice,
* Aways enable sarif report if present, even on scan failure.