### PR TITLE
feat: Switch to the latest versions of docker compose and yq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,16 @@ FROM cimg/base:edge-22.04 AS base
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source=https://github.com/DataDog/dd-trace-java-docker-build
 
+# Replace Docker Compose and yq versions from CircleCI Base Image by latest
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	sudo curl -sSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	sudo chmod +x $dockerPluginDir/docker-compose && \
+	sudo curl -fL "https://github.com/docker/compose-switch/releases/latest/download/docker-compose-linux-$(dpkg --print-architecture)" -o /usr/local/bin/compose-switch && \
+	sudo chmod +x /usr/local/bin/compose-switch && \
+    sudo curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64.tar.gz" | \
+	sudo tar -xz -C /usr/local/bin && \
+	sudo mv /usr/local/bin/yq{_linux_amd64,}
+
 COPY --from=default-jdk /usr/lib/jvm /usr/lib/jvm
 
 COPY autoforward.py /usr/local/bin/autoforward

--- a/build
+++ b/build
@@ -48,7 +48,9 @@ function do_build() {
         --platform linux/amd64 \
         --target full \
         --tag "$(image_name latest)" .
-    echo "LATEST_IMAGE_TAG=$(image_name latest)" >> $GITHUB_OUTPUT
+    if [ -n "${GITHUB_OUTPUT+unset}" ]; then
+        echo "LATEST_IMAGE_TAG=$(image_name latest)" >> $GITHUB_OUTPUT
+    fi
     for variant in "${BASE_VARIANTS[@]}"; do
         variant_lower="${variant,,}"
         docker tag "$(image_name base)" "$(image_name "${variant_lower}")"


### PR DESCRIPTION
As we got a continuous flow or security report about `docker compose` and `yq` coming from the CircleCI base image , I switch them by their latest versions. It should allow fixing issues by rebuilding the image on our side without having submit patches to upstream repository and wait for few weeks before it got merged.

For reference, [I asked to the upstream image maintainers if they are willing to move to GitHub latest release version](https://github.com/CircleCI-Public/cimg-base/pull/242#issuecomment-1521011004) as their Linux dependencies (`apt`) are not pinned either, but they are not.