### PR TITLE
fix: Trivy scan running out of space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,12 @@ jobs:
         run: ./build --test
       - name: Push images
         run: ./build --push
+      - name: Free Disk Space (Ubuntu) # Required by trivy to have enough space to scan full image
+        uses: jlumbroso/free-disk-space@76866dbe54312617f00798d1762df7f43def6e5c # v1.2.0
+      - name: Check space after freeing space
+        run: df -h
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0
+        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # v0.11.2
         with:
           image-ref: '${{ steps.build.outputs.LATEST_IMAGE_TAG }}'
           format: 'sarif'

--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0
+        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # v0.11.2
         with:
           image-ref: 'ghcr.io/datadog/dd-trace-java-docker-build:latest'
           format: 'sarif'


### PR DESCRIPTION
It should fix the current CI issue:
```
2023-06-08T08:11:25.644Z	WARN	Increase --timeout value
2023-06-08T08:11:25.648Z	FATAL	image scan error: scan error: scan failed: failed analysis: analyze error: semaphore acquire: context deadline exceeded
```

Also update the Trivy scanner version.