### PR TITLE
Fix Ubuntu17 distribution (security policies)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,13 @@ RUN set -eux; \
     sudo mkdir -p /usr/lib/jvm/oracle8; \
     curl -L --fail "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=246284_165374ff4ea84ef0bbd821706e29b123" | sudo tar -xvzf - -C /usr/lib/jvm/oracle8 --strip-components 1
 
+# Install Ubuntu's OpenJDK 17 and fix broken symlinks:
+# some files in /usr/lib/jvm/ubuntu17 are symlinks to /etc/java-17-openjdk/, so we just copy all symlinks targets.
 RUN set -eux;\
     sudo apt-get install openjdk-17-jdk;\
-    sudo mv /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/ubuntu17
+    sudo mv /usr/lib/jvm/java-17-openjdk-amd64 /usr/lib/jvm/ubuntu17;\
+    sudo cp -rf --remove-destination /etc/java-17-openjdk/* /usr/lib/jvm/ubuntu17/conf/;\
+    sudo cp -rf --remove-destination /etc/java-17-openjdk/* /usr/lib/jvm/ubuntu17/lib/;
 
 # Remove cruft from JDKs that is not used in the build process.
 RUN sudo rm -rf \


### PR DESCRIPTION
to fix the following exceptions:

```
Caused by: java.nio.file.NoSuchFileException: /usr/lib/jvm/ubuntu17/lib/security/default.policy
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.nio.file.Files.newByteChannel(Files.java:380)
	at java.nio.file.Files.newByteChannel(Files.java:432)
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
	at java.nio.file.Files.newInputStream(Files.java:160)
	at java.nio.file.Files.newBufferedReader(Files.java:2922)
	at java.nio.file.Files.newBufferedReader(Files.java:2955)
	at sun.security.provider.PolicyFile.initDefaultPolicy(PolicyFile.java:493)
	... 112 more
```