### PR TITLE
Add --describe command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: ./build
       - name: Test images
         run: ./build --test
+      - name: Describe images
+        run: ./build --describe
       - name: Push images
         run: ./build --push
       - name: Free Disk Space (Ubuntu) # Required by trivy to have enough space to scan full image

--- a/build
+++ b/build
@@ -152,6 +152,48 @@ function do_inner_test() {
     fi
 }
 
+function do_describe() {
+    local image
+    image="$(image_name latest)"
+    docker run \
+        -u "$(id -u):$(id -g)" \
+        -w /work \
+        -v "$(pwd):/work" \
+        --rm \
+        "$image" \
+        /work/build --inner-describe
+}
+
+function do_inner_describe() {
+    echo "# Contents"
+    echo
+    echo "## Operating System"
+    echo
+    echo "* $(lsb_release --description --short)"
+    echo
+    echo "## Tools"
+    echo
+    echo "* bash $BASH_VERSION"
+    echo "* $(git --version)"
+    echo "* $(docker --version)"
+    echo "* $(docker compose version)"
+    echo "* $(yq --version)"
+    echo "* datadog-ci $(datadog-ci version)"
+    echo
+    echo "## JDKs"
+    echo
+    for variant in "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
+        variant_upper="${variant^^}"
+        env_upper="JAVA_${variant_upper}_HOME"
+        echo "* $env_upper"
+        echo '```'
+        "${!env_upper}/bin/java" -version
+        echo '```'
+        echo
+    done
+    echo
+}
+
 function do_push() {
     local tag
     for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
@@ -168,6 +210,10 @@ elif [[ ${1} = "--test" ]]; then
 elif [[ ${1} = "--inner-test" ]]; then
     shift
     do_inner_test "$@"
+elif [[ ${1} = "--describe" ]]; then
+    do_describe
+elif [[ ${1} = "--inner-describe" ]]; then
+    do_inner_describe
 elif [[ ${1} = "--push" ]]; then
     do_push
 fi


### PR DESCRIPTION
Describes the contents of the built image in Markdown (e.g. for release notes).

<details>
  <summary>Example</summary>

# Contents

## Operating System

* Ubuntu 22.04.3 LTS

## Tools

* bash 5.1.16(1)-release
* git version 2.42.0
* Docker version 20.10.23, build 7155243
* Docker Compose version v2.22.0
* yq (https://github.com/mikefarah/yq/) version v4.35.1
* datadog-ci v1.3.0-alpha

## JDKs

* JAVA_8_HOME
```
openjdk version "1.8.0_382"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_382-b05)
OpenJDK 64-Bit Server VM (Temurin)(build 25.382-b05, mixed mode)
```

* JAVA_11_HOME
```
openjdk version "11.0.20.1" 2023-08-24
OpenJDK Runtime Environment Temurin-11.0.20.1+1 (build 11.0.20.1+1)
OpenJDK 64-Bit Server VM Temurin-11.0.20.1+1 (build 11.0.20.1+1, mixed mode, sharing)
```

* JAVA_17_HOME
```
openjdk version "17.0.8.1" 2023-08-24
OpenJDK Runtime Environment Temurin-17.0.8.1+1 (build 17.0.8.1+1)
OpenJDK 64-Bit Server VM Temurin-17.0.8.1+1 (build 17.0.8.1+1, mixed mode, sharing)
```

* JAVA_7_HOME
```
openjdk version "1.7.0_352"
OpenJDK Runtime Environment (Zulu 7.56.0.11-CA-linux64) (build 1.7.0_352-b01)
OpenJDK 64-Bit Server VM (Zulu 7.56.0.11-CA-linux64) (build 24.352-b01, mixed mode)
```

* JAVA_ZULU8_HOME
```
openjdk version "1.8.0_382"
OpenJDK Runtime Environment (Zulu 8.72.0.17-CA-linux64) (build 1.8.0_382-b05)
OpenJDK 64-Bit Server VM (Zulu 8.72.0.17-CA-linux64) (build 25.382-b05, mixed mode)
```

* JAVA_ZULU11_HOME
```
openjdk version "11.0.20.1" 2023-08-24 LTS
OpenJDK Runtime Environment Zulu11.66+19-CA (build 11.0.20.1+1-LTS)
OpenJDK 64-Bit Server VM Zulu11.66+19-CA (build 11.0.20.1+1-LTS, mixed mode)
```

* JAVA_ORACLE8_HOME
```
java version "1.8.0_331"
Java(TM) SE Runtime Environment (build 1.8.0_331-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.331-b09, mixed mode)
```

* JAVA_IBM8_HOME
```
java version "1.8.0_381"
Java(TM) SE Runtime Environment (build 8.0.8.10 - pxa6480sr8fp10-20230703_02(SR8 FP10))
IBM J9 VM (build 2.9, JRE 1.8.0 Linux amd64-64-Bit Compressed References 20230628_53798 (JIT enabled, AOT enabled)
OpenJ9   - a962f72
OMR      - 40dbd2d
IBM      - 696e9df)
JCL - 20230630_01 based on Oracle jdk8u381-b09
```

* JAVA_SEMERU8_HOME
```
openjdk version "1.8.0_382"
IBM Semeru Runtime Open Edition (build 1.8.0_382-b05)
Eclipse OpenJ9 VM (build openj9-0.40.0, JRE 1.8.0 Linux amd64-64-Bit Compressed References 20230810_729 (JIT enabled, AOT enabled)
OpenJ9   - d12d10c9e
OMR      - e80bff83b
JCL      - c4d2c2bafb based on jdk8u382-b05)
```

* JAVA_SEMERU11_HOME
```
openjdk version "11.0.20" 2023-07-18
IBM Semeru Runtime Open Edition 11.0.20.0 (build 11.0.20+8)
Eclipse OpenJ9 VM 11.0.20.0 (build openj9-0.40.0, JRE 11 Linux amd64-64-Bit Compressed References 20230810_825 (JIT enabled, AOT enabled)
OpenJ9   - d12d10c9e
OMR      - e80bff83b
JCL      - f53b132192 based on jdk-11.0.20+8)
```

* JAVA_SEMERU17_HOME
```
openjdk version "17.0.8" 2023-07-18
IBM Semeru Runtime Open Edition 17.0.8.0 (build 17.0.8+7)
Eclipse OpenJ9 VM 17.0.8.0 (build openj9-0.40.0, JRE 17 Linux amd64-64-Bit Compressed References 20230718_539 (JIT enabled, AOT enabled)
OpenJ9   - d12d10c9e
OMR      - e80bff83b
JCL      - 77b0f754805 based on jdk-17.0.8+7)
```

* JAVA_UBUNTU17_HOME
```
openjdk version "17.0.8.1" 2023-08-24
OpenJDK Runtime Environment (build 17.0.8.1+1-Ubuntu-0ubuntu122.04)
OpenJDK 64-Bit Server VM (build 17.0.8.1+1-Ubuntu-0ubuntu122.04, mixed mode, sharing)
```

* JAVA_GRAALVM17_HOME
```
openjdk version "17.0.8" 2023-07-18
OpenJDK Runtime Environment GraalVM CE 17.0.8+7.1 (build 17.0.8+7-jvmci-23.0-b15)
OpenJDK 64-Bit Server VM GraalVM CE 17.0.8+7.1 (build 17.0.8+7-jvmci-23.0-b15, mixed mode, sharing)
```

</details>