### PR TITLE
Add workflow to use versioned images

### DIFF
--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -1,5 +1,8 @@
 name: Tag new images version
 on:
+  schedule:
+    # Quarterly schedule, roughly aligned with JDK CPU
+    - cron: '0 0 30 1,4,7,10 *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -20,9 +20,3 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag images
         run: ./build --tag
-      - name: Create Pull Request
-        if: steps.changes-check.outputs.changed == 'true'
-        run: |
-          git commit -am 'Update base images'
-          git push origin HEAD:github-actions/docker-lock-update
-          gh pr create --title "Update base images" --base smola/staging --head github-actions/docker-lock-update

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -1,0 +1,28 @@
+name: Tag new images version
+on:
+  workflow_dispatch:
+
+jobs:
+  tag-images:
+    name: Tag new images version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # 3.3.0
+      - name: Login to ghcr.io
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # 2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag images
+        run: ./build --tag
+      - name: Create Pull Request
+        if: steps.changes-check.outputs.changed == 'true'
+        run: |
+          git commit -am 'Update base images'
+          git push origin HEAD:github-actions/docker-lock-update
+          gh pr create --title "Update base images" --base smola/staging --head github-actions/docker-lock-update

--- a/build
+++ b/build
@@ -204,7 +204,7 @@ function do_push() {
 }
 
 function do_tag() {
-    local tag token
+    local tag token version
     TAG_PREFIX=
     echo "Pulling latest images"
     for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
@@ -212,15 +212,12 @@ function do_tag() {
         tag="$(image_name "${tag}")"
         docker pull "$tag"
     done
-    token="$(curl "https://ghcr.io/token?scope=repository:datadog/dd-trace-java-docker-build:pull" | jq -r .token)"
-    latest_version="$(curl -s -k -X GET -H "Authorization: Bearer $token" -H "Accept: application/json" "https://ghcr.io/v2/datadog/dd-trace-java-docker-build/tags/list" | jq -r '.tags[]' | grep ^v | sed -e 's~^v~~g' -e 's~-.*~~g' | sort -rn | head -n 1)"
-    latest_version="${latest_version:-0}"
-    next_version="$((latest_version+1))"
-    echo "Latest version is v$latest_version, will tag v$next_version"
+    version="$(date +%y.%m)"
+    echo "Tagging version $version"
     for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
         tag="${tag,,}"
         tag="$(image_name "${tag}")"
-        new_tag="${tag/:/:v$next_version-}"
+        new_tag="${tag/:/:v$version-}"
         docker tag "$tag" "$new_tag"
         docker push "$new_tag"
     done

--- a/build
+++ b/build
@@ -203,6 +203,29 @@ function do_push() {
     done
 }
 
+function do_tag() {
+    local tag token
+    TAG_PREFIX=
+    echo "Pulling latest images"
+    for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
+        tag="${tag,,}"
+        tag="$(image_name "${tag}")"
+        docker pull "$tag"
+    done
+    token="$(curl "https://ghcr.io/token?scope=repository:datadog/dd-trace-java-docker-build:pull" | jq -r .token)"
+    latest_version="$(curl -s -k -X GET -H "Authorization: Bearer $token" -H "Accept: application/json" "https://ghcr.io/v2/datadog/dd-trace-java-docker-build/tags/list" | jq -r '.tags[]' | grep ^v | sed -e 's~^v~~g' -e 's~-.*~~g' | sort -rn | head -n 1)"
+    latest_version="${latest_version:-0}"
+    next_version="$((latest_version+1))"
+    echo "Latest version is v$latest_version, will tag v$next_version"
+    for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
+        tag="${tag,,}"
+        tag="$(image_name "${tag}")"
+        new_tag="${tag/:/:v$next_version-}"
+        docker tag "$tag" "$new_tag"
+        docker push "$new_tag"
+    done
+}
+
 if [[ -z ${1:-} ]]; then
     do_build
 elif [[ ${1} = "--test" ]]; then
@@ -216,4 +239,6 @@ elif [[ ${1} = "--inner-describe" ]]; then
     do_inner_describe
 elif [[ ${1} = "--push" ]]; then
     do_push
+elif [[ ${1} = "--tag" ]]; then
+    do_tag
 fi


### PR DESCRIPTION
* [Tag new images](https://github.com/DataDog/dd-trace-java-docker-build/actions/workflows/docker-tag.yml) workflow can be triggered to tag the latest version of all images.
* Version is based on year and month, and the resulting tags will prepend `vN-` to the image tag (e.g. `zulu11` -> `v23.09-zulu11`).