### PR TITLE
chore: Update CI Visibility script to always use latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN <<-EOT
 	pip3 install requests requests-unixsocket
 	pip3 cache purge
 	sudo chmod +x /usr/local/bin/autoforward
-	sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v1.3.0-alpha/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
+	sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
 	sudo chmod +x /usr/local/bin/datadog-ci
 EOT
 


### PR DESCRIPTION
We noticed that we were missing some key features in our CI Visibility dashboard, such as `test.codeowners`

This change updates our script to always pull [datadog-ci#latest](https://github.com/DataDog/datadog-ci/releases/latest)

Worst case scenario is we break data upload for nightly builds. In that case, this change can be safely reverted