### PR TITLE
Prevent workflows to be disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+  keepalive-job:
+    name: Keep repository alive to prevent workflows to be disabled
+    if: ${{ always() }}
+    needs: build_push_and_check
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          use_api: true


### PR DESCRIPTION
GitHub disables workflow scheduled runs if there is no activity during the last 60 days.
This PR adds an action to notify of new activity if there was none during the last 50 days.
This should prevent GitHub to disable our builds.