### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_push_and_check:
+  build_push_check:
     name: Build docker image, publish it and run vuln scanner against it
     permissions:
       contents: read # for actions/checkout to fetch code
@@ -22,16 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # 2.4.1
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # 3.6.1
       - name: Login to ghcr.io
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # 2.1.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # 3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free Disk Space (Ubuntu) # Reclaim disk space for build
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          docker-images: false # Do not remove locally built images (including trivy scanner)
       - name: Build images
         id: build
         run: ./build
@@ -41,12 +45,8 @@ jobs:
         run: ./build --describe >> $GITHUB_STEP_SUMMARY
       - name: Push images
         run: ./build --push
-      - name: Free Disk Space (Ubuntu) # Required by trivy to have enough space to scan full image
-        uses: jlumbroso/free-disk-space@76866dbe54312617f00798d1762df7f43def6e5c # v1.2.0
-        with:
-          large-packages: false # Temporary fix for https://github.com/jlumbroso/free-disk-space/issues/4
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # v0.11.2
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
         with:
           image-ref: '${{ steps.build.outputs.LATEST_IMAGE_TAG }}'
           format: 'sarif'
@@ -54,20 +54,19 @@ jobs:
           severity: 'CRITICAL,HIGH'
           limit-severities-for-sarif: true
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+
   keepalive-job:
     name: Keep repository alive to prevent workflows to be disabled
     if: ${{ always() }}
-    needs: build_push_and_check
+    needs: build_push_check
     permissions:
-      actions: write
+      actions: write # for gautamkrishnar/keepalive-workflow to keep the workflow alive
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
       - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@306efe4fc63923e36571682b4f4b3e3eee8b6625 # v1.2.6
-        with:
-          use_api: true
+        uses: gautamkrishnar/keepalive-workflow@24ba73b43d5ea8d2b3d56fb9b8de951ba9a3dd18 # v2.0.6

--- a/.github/workflows/docker-tag.yml
+++ b/.github/workflows/docker-tag.yml
@@ -14,9 +14,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # 3.3.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
       - name: Login to ghcr.io
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # 2.1.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # 3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/registry-cleanup.yml
+++ b/.github/workflows/registry-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
     steps:
     - name: Prune untagged images
-      uses: vlaurin/action-ghcr-prune@0a539594d122b915e71c59733a5b115bfaaf5d52 #v0.5.0
+      uses: vlaurin/action-ghcr-prune@0cf7d39f88546edd31965acba78cdcb0be14d641 #v0.6.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         organization: Datadog

--- a/.github/workflows/vuln-check.yml
+++ b/.github/workflows/vuln-check.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Free Disk Space (Ubuntu) # Required by trivy to have enough space to scan full image
-        uses: jlumbroso/free-disk-space@76866dbe54312617f00798d1762df7f43def6e5c # v1.2.0
+      - name: Free Disk Space (Ubuntu) # Reclaim disk space for scan
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          large-packages: false # Temporary fix for https://github.com/jlumbroso/free-disk-space/issues/4
+          docker-images: false # Do not remove locally built images (including trivy scanner)
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # v0.11.2
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
         with:
           image-ref: 'ghcr.io/datadog/dd-trace-java-docker-build:latest'
           format: 'sarif'
@@ -39,7 +39,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR should fix the current build issues by:

* Reclaiming space before building docker images (no space left on runner)
* Avoiding cleaning docker image while reclaiming runner space (Trivy locally build its scanner image)
* Removing large-packages workaround (no more needed)
* Upgrading the GitHub actions to their latest versions (some were deprecated)