### PR TITLE
feat: Use CircleCI current instead of edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.6
 
 # Intermediate image used to prune cruft from JDKs and squash them all.
-FROM cimg/base:edge-22.04 AS all-jdk
+FROM cimg/base:current-22.04 AS all-jdk
 
 COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
 COPY --from=eclipse-temurin:11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/11
@@ -59,7 +59,7 @@ COPY --from=all-jdk /usr/lib/jvm/21 /usr/lib/jvm/21
 
 # Base image with minimunm requirenents to build the project.
 # Based on CircleCI Base Image with Ubuntu 22.04.3 LTS, present in most runners.
-FROM cimg/base:edge-22.04 AS base
+FROM cimg/base:current-22.04 AS base
 
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source=https://github.com/DataDog/dd-trace-java-docker-build


### PR DESCRIPTION
According to CircleCI CI, edge is only tagged when active development whereas current is still tagged on a monthly basis. This should avoid relying on outdated image when no development occurs.

In addition:

> Edge - This tag is not recommended for production software.

> Current - This image tag points to the latest, production ready base image

From [Tagging Scheme section](https://circleci.com/developer/images/image/cimg/base).