### PR TITLE
Clean up built-in tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,14 +64,14 @@ FROM cimg/base:current-22.04 AS base
 # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package
 LABEL org.opencontainers.image.source=https://github.com/DataDog/dd-trace-java-docker-build
 
-# Replace Docker Compose and yq versions from CircleCI Base Image by latest
+# Replace Docker Compose and yq versions by latest and remove docker-switch from CircleCI Base Image for security purposes
 RUN <<-EOT
 	set -eu
 	dockerPluginDir=/usr/local/lib/docker/cli-plugins
 	sudo curl -sSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose
 	sudo chmod +x $dockerPluginDir/docker-compose
-	sudo curl -fL "https://github.com/docker/compose-switch/releases/latest/download/docker-compose-linux-$(dpkg --print-architecture)" -o /usr/local/bin/compose-switch
-	sudo chmod +x /usr/local/bin/compose-switch
+	sudo sudo update-alternatives --remove docker-compose /usr/local/bin/compose-switch
+	sudo rm -f /usr/local/bin/compose-switch
 	sudo rm /usr/local/bin/{install-man-page.sh,yq*}
 	curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture).tar.gz" | sudo tar -xz -C /usr/local/bin --wildcards --no-anchored 'yq_linux_*'
 	sudo mv /usr/local/bin/yq{_linux_*,}

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,10 @@ COPY --from=default-jdk /usr/lib/jvm /usr/lib/jvm
 
 COPY autoforward.py /usr/local/bin/autoforward
 
-# Force downgrade of urllib3 to work around https://github.com/docker/docker-py/issues/3113
-# Install urllib3 early since it is also used by awscli
+# Install the following tools
+# - awscli: AWS CLI
+# - autoforward dependencies: tool to forward request to a remote Docker deamon
+# - datadog-ci: Datadog CI tool
 RUN <<-EOT
 	set -eux
 	sudo apt-get update
@@ -94,7 +96,7 @@ RUN <<-EOT
 	sudo apt install python3-pip
 	sudo apt-get -y clean
 	sudo rm -rf /var/lib/apt/lists/*
-	pip3 install "urllib3>=1.25.4,<2" awscli
+	pip3 install awscli
 	pip3 install requests requests-unixsocket
 	pip3 cache purge
 	sudo chmod +x /usr/local/bin/autoforward

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN <<-EOT
 	sudo apt-get -y clean
 	sudo rm -rf /var/lib/apt/lists/*
 	pip3 install awscli
-	pip3 install requests requests-unixsocket
+	pip3 install requests requests-unixsocket2
 	pip3 cache purge
 	sudo chmod +x /usr/local/bin/autoforward
 	sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"


### PR DESCRIPTION
This PR removes `compose-switch`, removes an old workaround, and fix `autoforward` script.

### Compose switch

Remove `compose-switch`, a binary in charge of forwarding calls from `docker-compose` (V1, deprecated) to `docker compose` (V2). `compose-switch` was not updated for 2y+ and brings security issues.

### Workaround

Unpin the urllib package from `awscli`.

### Autoforward

The python package `requests` introduced behavior break in 2.32 on validating scheme: https://github.com/psf/requests/issues/6707
As `requests-unixsocket` is no more maintained, a fork was put in place to fix the issue: https://github.com/msabramo/requests-unixsocket/issues/73


This changed is tested here: https://github.com/DataDog/dd-trace-java/pull/7486