### PR TITLE
Add keep alive workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
         with:
           sarif_file: 'trivy-results.sarif'
-
-  keepalive-job:
-    name: Keep repository alive to prevent workflows to be disabled
-    if: ${{ always() }}
-    needs: build_push_check
-    permissions:
-      actions: write # for gautamkrishnar/keepalive-workflow to keep the workflow alive
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-      - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@2a8ae70f39b79fb50659d17ccc6f372f461813b2 # v2.0.10

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,34 @@
+name: Keep Workflow Alive
+description: |
+  This workflow is designed to keep the repository alive by making a dummy commit
+  to the `keepalive` branch to make sure the GitHub workflow will continue to run.
+  It runs on a weekly schedule and can also be triggered manually via the GitHub
+  Actions UI.
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push changes to the repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Make dummy commit to keep workflow alive
+        run: |
+          git fetch origin keepalive
+          git checkout keepalive
+          echo "Last update from $(date -u)" > keepalive
+          git add keepalive
+          git commit -m "chore: keepalive" || echo "No changes to commit"
+          git push origin keepalive


### PR DESCRIPTION
This PR adds a new keep alive workflow that will push dummy commit to the `keepalive` branch.
This will ensure the GitHub workflow will continue to run to build image even if there is no maintenance on the repository.