### PR TITLE
Change Oracle Java 8 link to use JDK 8u401, because latest link is JRE only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,12 @@ COPY --from=ghcr.io/graalvm/native-image-community:17-ol9 /usr/lib64/graalvm/gra
 COPY --from=ghcr.io/graalvm/native-image-community:21-ol9 /usr/lib64/graalvm/graalvm-community-java21 /usr/lib/jvm/graalvm21
 
 # See: https://gist.github.com/wavezhang/ba8425f24a968ec9b2a8619d7c2d86a6
+# Note it seems that latest Oracle JDK 8 are not available for download without an account.
+# Latest availble is jdk-8u381-linux-x64.tar.gz
 RUN <<-EOT
 	set -eux
 	sudo mkdir -p /usr/lib/jvm/oracle8
-	sudo curl -L --fail "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=252034_8a1589aa0fe24566b4337beee47c2d29" | sudo tar -xvzf - -C /usr/lib/jvm/oracle8 --strip-components 1
+	sudo curl -L --fail "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=248746_8c876547113c4e4aab3c868e9e0ec572" | sudo tar -xvzf - -C /usr/lib/jvm/oracle8 --strip-components 1
 EOT
 
 # Install Ubuntu's OpenJDK 17 and fix broken symlinks:


### PR DESCRIPTION
Latest links from https://gist.github.com/wavezhang/ba8425f24a968ec9b2a8619d7c2d86a6 are JRE only.

The changed link points to `jdk-8u381-linux-x64.tar.gz`.