### PR TITLE
Update docker and docker-compose versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       gh-actions-packages:
         patterns:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,12 @@ RUN <<-EOT
 	sudo git config --system --add safe.directory "*"
 	
 	sudo mkdir -p /tmp/docker-install
-	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-28.2.2.tgz" | sudo tar -xz -C /tmp/docker-install
+	DOCKER_LATEST_VERSION=$(curl -s https://download.docker.com/linux/static/stable/$(uname -m)/ | grep -oP 'docker-\K([0-9]+\.[0-9]+\.[0-9]+)(?=\.tgz)' | sort -V | tail -n 1)
+	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_LATEST_VERSION}.tgz" | sudo tar -xz -C /tmp/docker-install
 	sudo mv /tmp/docker-install/docker/docker /usr/local/bin/
 	sudo rm -rf /tmp/docker-install
 	sudo mkdir -p /usr/local/lib/docker/cli-plugins
-	sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.0/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+	sudo curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
 	sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 	
 	sudo apt-get clean
@@ -141,11 +142,12 @@ RUN <<-EOT
 	sudo git config --system --add safe.directory "*"
 	
 	sudo mkdir -p /tmp/docker-install
-	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-28.2.2.tgz" | sudo tar -xz -C /tmp/docker-install
+	DOCKER_LATEST_VERSION=$(curl -s https://download.docker.com/linux/static/stable/$(uname -m)/ | grep -oP 'docker-\K([0-9]+\.[0-9]+\.[0-9]+)(?=\.tgz)' | sort -V | tail -n 1)
+	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_LATEST_VERSION}.tgz" | sudo tar -xz -C /tmp/docker-install
 	sudo mv /tmp/docker-install/docker/docker /usr/local/bin/
 	sudo rm -rf /tmp/docker-install
 	sudo mkdir -p /usr/local/lib/docker/cli-plugins
-	sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.0/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+	sudo curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
 	sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 	
 	sudo apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,11 @@ RUN <<-EOT
 	sudo git config --system --add safe.directory "*"
 	
 	sudo mkdir -p /tmp/docker-install
-	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-24.0.7.tgz" | sudo tar -xz -C /tmp/docker-install
+	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-28.2.2.tgz" | sudo tar -xz -C /tmp/docker-install
 	sudo mv /tmp/docker-install/docker/docker /usr/local/bin/
 	sudo rm -rf /tmp/docker-install
 	sudo mkdir -p /usr/local/lib/docker/cli-plugins
-	sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.24.6/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+	sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.0/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
 	sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 	
 	sudo apt-get clean
@@ -66,7 +66,7 @@ COPY --from=ghcr.io/graalvm/native-image-community:21-ol9 /usr/lib64/graalvm/gra
 
 # See: https://gist.github.com/wavezhang/ba8425f24a968ec9b2a8619d7c2d86a6
 # Note it seems that latest Oracle JDK 8 are not available for download without an account.
-# Latest availble is jdk-8u381-linux-x64.tar.gz
+# Latest available is jdk-8u381-linux-x64.tar.gz
 RUN <<-EOT
 	set -eux
 	sudo mkdir -p /usr/lib/jvm/oracle8
@@ -141,11 +141,11 @@ RUN <<-EOT
 	sudo git config --system --add safe.directory "*"
 	
 	sudo mkdir -p /tmp/docker-install
-	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-24.0.7.tgz" | sudo tar -xz -C /tmp/docker-install
+	sudo curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-28.2.2.tgz" | sudo tar -xz -C /tmp/docker-install
 	sudo mv /tmp/docker-install/docker/docker /usr/local/bin/
 	sudo rm -rf /tmp/docker-install
 	sudo mkdir -p /usr/local/lib/docker/cli-plugins
-	sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.24.6/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+	sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.37.0/docker-compose-linux-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
 	sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 	
 	sudo apt-get clean


### PR DESCRIPTION
Fix security vulnerabilities (https://github.com/DataDog/dd-trace-java-docker-build/security/code-scanning) by updating docker and docker compose versions.

Also update dependabot frequency from monthly to weekly.

Check that the security vulnerabilities are fixed in this PR [here](https://github.com/DataDog/dd-trace-java-docker-build/security/code-scanning?query=is%3Aopen+pr%3A100). [This vulnerability](https://github.com/DataDog/dd-trace-java-docker-build/security/code-scanning/562) (high) is still not resolved; however, there is no "fixed version" available yet.