### PR TITLE
Fix Ubuntu17

### DIFF
--- a/build
+++ b/build
@@ -103,9 +103,13 @@ function do_build() {
     for variant in "${VARIANTS[@]}"; do
         variant_upper="${variant^^}"
         variant_lower="${variant,,}"
-        docker_build variant "$(image_name "$variant_lower")" \
-            --build-arg "VARIANT_UPPER=$variant_upper" \
-            --build-arg "VARIANT_LOWER=$variant_lower"
+        if [[ $variant == "ubuntu17" ]]; then
+            docker_build ubuntu17 "$(image_name "${variant_lower}")"
+        else
+            docker_build variant "$(image_name "$variant_lower")" \
+                --build-arg "VARIANT_UPPER=$variant_upper" \
+                --build-arg "VARIANT_LOWER=$variant_lower"
+        fi
     done
 }
 


### PR DESCRIPTION
Our Ubuntu 17 variant has an incorrect setup of the trust store. Avoid the JDK stripping trickery for Ubuntu 17, and use it from a clean install.