### PR TITLE
Change image name stable to latest_non_lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker images for continuous integration jobs at [dd-trace-java](https://github.
 Pre-built images are available in [GitHub Container Registry](https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build).
 
 Image variants are available on a per JDK basis:
-- The `base` variant, and its aliases `8`, `11`, `17`, `21`, and `stable`, contains the base Eclipse Temurin JDK 8, 11, 17, 21, and latest stable JDK versions,
+- The `base` variant, and its aliases `8`, `11`, `17`, `21`, and `latest_non_lts`, contains the base Eclipse Temurin JDK 8, 11, 17, 21, and latest non-LTS JDK versions,
 - The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm17` and `graalvm21` variants all contain the base JDKs in addition to the specific JDK from their name,
 - The `latest` variant contains the base JDKs and all the above specific JDKs.
 

--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -eu
 
 readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
-readonly BASE_VARIANTS=(8 11 17 21 stable) # add an ea variant once the early access build is available
+readonly BASE_VARIANTS=(8 11 17 21 latest_non_lts) # add an ea variant once the early access build is available
 
 readonly VARIANTS=(
     7
@@ -160,7 +160,7 @@ function do_inner_test() {
     "$JAVA_21_HOME/bin/java" -version
     "${!java_latest_home}/bin/java" -version
     if [[ $variant != base && $variant != latest ]]; then
-        if [[ $variant == "stable" ]]; then
+        if [[ $variant == "latest_non_lts" ]]; then
             variant_lower="${LATEST_VERSION}"
             variant_upper="${LATEST_VERSION}"
         fi
@@ -202,7 +202,7 @@ function do_inner_describe() {
     echo "## JDKs"
     echo
     for variant in "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
-        if [[ $variant == "stable" ]]; then
+        if [[ $variant == "latest_non_lts" ]]; then
             variant_upper="${LATEST_VERSION}"
         else
             variant_upper="${variant^^}"


### PR DESCRIPTION
Changing the name distinguishes the latest "stable" image VS. "latest non-LTS" stable version. This will be relevant once LTS version JDK 25 comes out in September 2025. We would then test against JDK 24 (then JDK 26 and so on) alongside JDK 25, which should be separately pinned as LTS.