### PR TITLE
Update Java 25 image to GA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,7 @@ COPY --from=eclipse-temurin:8-jdk-jammy /opt/java/openjdk /usr/lib/jvm/8
 COPY --from=eclipse-temurin:11-jdk-jammy /opt/java/openjdk /usr/lib/jvm/11
 COPY --from=eclipse-temurin:17-jdk-jammy /opt/java/openjdk /usr/lib/jvm/17
 COPY --from=eclipse-temurin:21-jdk-jammy /opt/java/openjdk /usr/lib/jvm/21
-# TODO: Update to eclipse-temurin once JDK 25 is generally available (ETA Sep 16).
-COPY --from=openjdk:25-jdk-bookworm /usr/local/openjdk-25 /usr/lib/jvm/25
+COPY --from=eclipse-temurin:25-jdk-noble /opt/java/openjdk /usr/lib/jvm/25
 COPY --from=temurin-latest /opt/java/openjdk /usr/lib/jvm/${LATEST_VERSION}
 
 COPY --from=azul/zulu-openjdk:7 /usr/lib/jvm/zulu7 /usr/lib/jvm/7

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker images for continuous integration jobs at [dd-trace-java](https://github.
 Pre-built images are available in [GitHub Container Registry](https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build).
 
 Image variants are available on a per JDK basis:
-- The `base` variant, and its aliases `8`, `11`, `17`, `21`, `25`, and `stable`, contains the base Eclipse Temurin JDK 8, 11, 17, 21, 25 early access, and latest stable JDK versions,
+- The `base` variant and its aliases, `8`, `11`, `17`, `21`, `25`, and `stable`, contain the base Eclipse Temurin JDK 8, 11, 17, 21, 25, and latest stable JDK versions,
 - The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm17` and `graalvm21` variants all contain the base JDKs in addition to the specific JDK from their name,
 - The `latest` variant contains the base JDKs and all the above specific JDKs.
 

--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -eu
 
 readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
-readonly BASE_VARIANTS=(8 11 17 21 25 stable) # add an ea variant once the early access build is available
+readonly BASE_VARIANTS=(8 11 17 21 25 stable)
 
 readonly VARIANTS=(
     7


### PR DESCRIPTION
Switch to the general release of JDK 25.

Testing [here](https://github.com/DataDog/dd-trace-java/pull/9630).

Jira ticket: [datadoghq.atlassian.net/browse/LANGPLAT-83](https://datadoghq.atlassian.net/browse/LANGPLAT-83)