### PR TITLE
Add vault to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ WORKDIR /home/non-root-user
 RUN <<-EOT
 	set -eux
 	sudo apt-get update
-	sudo apt-get install -y curl tar apt-transport-https ca-certificates gnupg socat less debian-goodies autossh ca-certificates-java python3-pip locales jq git gh yq lsb-release lsof
+	sudo apt-get install -y curl tar apt-transport-https ca-certificates gnupg socat less debian-goodies autossh ca-certificates-java python3-pip locales jq git gh yq lsb-release lsof unzip
 	sudo locale-gen en_US.UTF-8
 	sudo git config --system --add safe.directory "*"
 	
@@ -154,8 +154,19 @@ RUN <<-EOT
 	sudo apt-get update
 	sudo pip3 install --break-system-packages awscli
 	sudo pip3 cache purge
+
+	# datadog-ci
 	sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
 	sudo chmod +x /usr/local/bin/datadog-ci
+
+	# vault
+	VAULT_VERSION=1.20.4
+	curl -fsSL "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o vault.zip
+	unzip vault.zip
+	sudo mv vault /usr/local/bin/vault
+	chmod +x /usr/local/bin/vault
+	rm vault.zip
+
 	sudo apt-get clean
 	sudo rm -rf /var/lib/apt/lists/*
 EOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,7 @@ COPY --from=default-jdk /usr/lib/jvm /usr/lib/jvm
 # Install the following tools
 # - awscli: AWS CLI
 # - datadog-ci: Datadog CI tool
+# - vault: tool for managing secrets: https://datadoghq.atlassian.net/wiki/spaces/RUNTIME/pages/2701559033/Vault
 RUN <<-EOT
 	set -eux
 	sudo apt-get update
@@ -159,7 +160,7 @@ RUN <<-EOT
 	sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci"
 	sudo chmod +x /usr/local/bin/datadog-ci
 
-	# vault
+	# vault installation inspired by https://github.com/DataDog/datadog-agent-buildimages/blob/main/agent-deploy/Dockerfile
 	VAULT_VERSION=1.20.4
 	curl -fsSL "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o vault.zip
 	unzip vault.zip

--- a/build
+++ b/build
@@ -200,6 +200,7 @@ function do_inner_describe() {
     echo "* $(docker --version)"
     echo "* $(docker compose version)"
     echo "* datadog-ci $(datadog-ci version)"
+    echo "* vault $(vault --version)"
     echo
     echo "## JDKs"
     echo


### PR DESCRIPTION
We'll need to use Vault as a tool for managing secrets: https://datadoghq.atlassian.net/wiki/spaces/RUNTIME/pages/2701559033/Vault

I also added `vault --version` to the build script in order to confirm that it gets successfully installed (it does)!