### PR TITLE
Add JDK 26 EA image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ COPY --from=eclipse-temurin:11-jdk-noble /opt/java/openjdk /usr/lib/jvm/11
 COPY --from=eclipse-temurin:17-jdk-noble /opt/java/openjdk /usr/lib/jvm/17
 COPY --from=eclipse-temurin:21-jdk-noble /opt/java/openjdk /usr/lib/jvm/21
 COPY --from=eclipse-temurin:25-jdk-noble /opt/java/openjdk /usr/lib/jvm/25
+# TODO: Update to more stable version once released. GA ETA is Mar 17 2026.
+COPY --from=openjdk:26-ea-jdk-bookworm /usr/local/openjdk-26 /usr/lib/jvm/26
 COPY --from=temurin-latest /opt/java/openjdk /usr/lib/jvm/${LATEST_VERSION}
 
 COPY --from=azul/zulu-openjdk:7 /usr/lib/jvm/zulu7 /usr/lib/jvm/7
@@ -99,6 +101,7 @@ COPY --from=all-jdk /usr/lib/jvm/11 /usr/lib/jvm/11
 COPY --from=all-jdk /usr/lib/jvm/17 /usr/lib/jvm/17
 COPY --from=all-jdk /usr/lib/jvm/21 /usr/lib/jvm/21
 COPY --from=all-jdk /usr/lib/jvm/25 /usr/lib/jvm/25
+COPY --from=all-jdk /usr/lib/jvm/26 /usr/lib/jvm/26
 COPY --from=all-jdk /usr/lib/jvm/${LATEST_VERSION} /usr/lib/jvm/${LATEST_VERSION}
 
 # Base image with minimum requirements to build the project.
@@ -190,6 +193,7 @@ ENV JAVA_11_HOME=/usr/lib/jvm/11
 ENV JAVA_17_HOME=/usr/lib/jvm/17
 ENV JAVA_21_HOME=/usr/lib/jvm/21
 ENV JAVA_25_HOME=/usr/lib/jvm/25
+ENV JAVA_26_HOME=/usr/lib/jvm/26
 ENV JAVA_${LATEST_VERSION}_HOME=/usr/lib/jvm/${LATEST_VERSION}
 
 ENV JAVA_HOME=${JAVA_8_HOME}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository holds Docker images for continuous integration jobs at [dd-trace
 Pre-built images are available in [GitHub Container Registry](https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build).
 
 Image variants are available on a per JDK basis:
-- The `base` variant and its aliases, `8`, `11`, `17`, `21`, `25`, and `stable`, contain the base Eclipse Temurin JDK 8, 11, 17, 21, 25, and latest stable JDK versions,
+- The `base` variant and its aliases, `8`, `11`, `17`, `21`, `25`, `26`, and `stable`, contain the base Eclipse Temurin JDK 8, 11, 17, 21, 25, 26 early access, and latest stable JDK versions,
 - The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm17`, `graalvm21`, and `graalvm25` variants all contain the base JDKs in addition to the specific JDK from their name,
 - The `latest` variant contains the base JDKs and all the above specific JDKs.
 

--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -eu
 
 readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
-readonly BASE_VARIANTS=(8 11 17 21 25 stable)
+readonly BASE_VARIANTS=(8 11 17 21 25 26 stable)
 
 readonly VARIANTS=(
     7
@@ -161,6 +161,7 @@ function do_inner_test() {
     "$JAVA_17_HOME/bin/java" -version
     "$JAVA_21_HOME/bin/java" -version
     "$JAVA_25_HOME/bin/java" -version
+    "$JAVA_26_HOME/bin/java" -version
     "${!java_latest_home}/bin/java" -version
     if [[ $variant != base && $variant != latest ]]; then
         if [[ $variant == "stable" ]]; then


### PR DESCRIPTION
Use `openjdk` early access image for testing purposes only. We should progressively update this image to improve stability until GA.

Testing with: https://github.com/DataDog/dd-trace-java/pull/9992

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-903