### PR TITLE
Rename "stable" image name to "tip"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=eclipse-temurin:11-jdk-noble /opt/java/openjdk /usr/lib/jvm/11
 COPY --from=eclipse-temurin:17-jdk-noble /opt/java/openjdk /usr/lib/jvm/17
 COPY --from=eclipse-temurin:21-jdk-noble /opt/java/openjdk /usr/lib/jvm/21
 COPY --from=eclipse-temurin:25-jdk-noble /opt/java/openjdk /usr/lib/jvm/25
-# TODO: Update to more stable version once released. GA ETA is Mar 17 2026.
+# TODO: Update once 26 is officially released. GA ETA is Mar 17 2026.
 COPY --from=openjdk:26-rc-jdk-bookworm /usr/local/openjdk-26 /usr/lib/jvm/26
 COPY --from=temurin-latest /opt/java/openjdk /usr/lib/jvm/${LATEST_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository holds Docker images for continuous integration jobs at [dd-trace
 Pre-built images are available in [GitHub Container Registry](https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build).
 
 Image variants are available on a per JDK basis:
-- The `base` variant and its aliases, `8`, `11`, `17`, `21`, `25`, `26`, and `stable`, contain the base Eclipse Temurin JDK 8, 11, 17, 21, 25, 26 early access, and latest stable JDK versions,
+- The `base` variant and its aliases, `8`, `11`, `17`, `21`, `25`, and `tip`, contain the base Eclipse Temurin JDK 8, 11, 17, 21, 25, and tip JDK version releases,
 - The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm17`, `graalvm21`, and `graalvm25` variants all contain the base JDKs in addition to the specific JDK from their name,
 - The `latest` variant contains the base JDKs and all the above specific JDKs.
 

--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -eu
 
 readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
-readonly BASE_VARIANTS=(8 11 17 21 25 tip)
+readonly BASE_VARIANTS=(8 11 17 21 25 26 tip) # TODO: Remove 26 after officially released (tip will then refer to 26)
 
 readonly VARIANTS=(
     7

--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -eu
 
 readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
-readonly BASE_VARIANTS=(8 11 17 21 25 26 stable)
+readonly BASE_VARIANTS=(8 11 17 21 25 tip)
 
 readonly VARIANTS=(
     7
@@ -164,7 +164,7 @@ function do_inner_test() {
     "$JAVA_26_HOME/bin/java" -version
     "${!java_latest_home}/bin/java" -version
     if [[ $variant != base && $variant != latest ]]; then
-        if [[ $variant == "stable" ]]; then
+        if [[ $variant == "tip" ]]; then
             variant_lower="${LATEST_VERSION}"
             variant_upper="${LATEST_VERSION}"
         fi
@@ -207,7 +207,7 @@ function do_inner_describe() {
     echo "## JDKs"
     echo
     for variant in "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
-        if [[ $variant == "stable" ]]; then
+        if [[ $variant == "tip" ]]; then
             variant_upper="${LATEST_VERSION}"
         else
             variant_upper="${variant^^}"


### PR DESCRIPTION
"tip" better follows OpenJDK naming conventions: https://openjdk.org/jeps/14

Jira card: https://datadoghq.atlassian.net/browse/APMLP-1063

Test PR: https://github.com/DataDog/dd-trace-java/pull/10682