### PR TITLE
Tag CI images with `ci-` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Image variants are available on a per JDK basis:
 - The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm17`, `graalvm21`, and `graalvm25` variants all contain the base JDKs in addition to the specific JDK from their name,
 - The `latest` variant contains the base JDKs and all the above specific JDKs.
 
-Images are tagged via the [Tag new images version](https://github.com/DataDog/dd-trace-java-docker-build/actions/workflows/docker-tag.yml) workflow. This workflow tags the latest images built from the specified branch using the `vYY.MM` format. It runs quarterly on `master` but can also be triggered manually as needed.
+Images are tagged via the [Tag new images version](https://github.com/DataDog/dd-trace-java-docker-build/actions/workflows/docker-tag.yml) workflow. This workflow tags the latest images built from the specified branch with a `ci-` prefix. It runs quarterly on `master` but can also be triggered manually as needed.
 
 ## Development
 

--- a/build
+++ b/build
@@ -233,7 +233,7 @@ function do_push() {
 }
 
 function do_tag() {
-    local tag token version
+    local tag
     TAG_PREFIX=
     echo "Pulling latest images"
     for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
@@ -241,12 +241,11 @@ function do_tag() {
         tag="$(image_name "${tag}")"
         docker pull "$tag"
     done
-    version="$(date +%y.%m)"
-    echo "Tagging version $version"
+    echo "Tagging ci- images"
     for tag in base latest "${BASE_VARIANTS[@]}" "${VARIANTS[@]}"; do
         tag="${tag,,}"
         tag="$(image_name "${tag}")"
-        new_tag="${tag/:/:v$version-}"
+        new_tag="${tag/:/:ci-}"
         docker tag "$tag" "$new_tag"
         docker push "$new_tag"
     done


### PR DESCRIPTION
Replace `vYY.MM-` tag with `ci-` tag for images we use in CI. 

A stable name will simplify the process of mirroring our images to `registry.dd.io` (necessary because `dd-trace-java` CI requires signed images). This PR will be followed by https://github.com/DataDog/images/pull/9015.