### PR TITLE
Specify pushing to `images` repo

### DIFF
--- a/.github/workflows/create-test-mirror-pr.yml
+++ b/.github/workflows/create-test-mirror-pr.yml
@@ -80,6 +80,7 @@ jobs:
         if: ${{ steps.create-commit.outputs.has_changes == 'true' }}
         uses: DataDog/commit-headless@05d7b7ee023e2c7d01c47832d420c2503cd416f3 # action/v2.0.3
         with:
+          target: DataDog/images
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
           head-sha: "${{ steps.images-head.outputs.sha }}"

--- a/.github/workflows/update-mirror-digests.yml
+++ b/.github/workflows/update-mirror-digests.yml
@@ -97,6 +97,7 @@ jobs:
         if: ${{ steps.create-commit.outputs.has_changes == 'true' }}
         uses: DataDog/commit-headless@05d7b7ee023e2c7d01c47832d420c2503cd416f3 # action/v2.0.3
         with:
+          target: DataDog/images
           token: "${{ steps.octo-sts.outputs.token }}"
           branch: "${{ steps.define-branch.outputs.branch }}"
           head-sha: "${{ steps.images-head.outputs.sha }}"


### PR DESCRIPTION
Ensure that `create-test-mirror-pr` and `update-mirror-digests` workflows push PRs to the `DataDog/images` repo

Recent workflow failure from pushing to `DataDog/dd-trace-java-docker-build`: https://github.com/DataDog/dd-trace-java-docker-build/actions/runs/23010758685/job/66820282754