### PR TITLE
Fix commit push Github Action workflows

### DIFF
--- a/.github/workflows/create-test-mirror-pr.yml
+++ b/.github/workflows/create-test-mirror-pr.yml
@@ -73,7 +73,6 @@ jobs:
           fi
           git commit -m "chore: Update dd-trace-java-docker-build test image digests for PR #${PR_NUMBER}"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         working-directory: images
 
       - name: Push changes
@@ -86,7 +85,6 @@ jobs:
           head-sha: "${{ steps.images-head.outputs.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
           working-directory: images
 
       - name: Create pull request

--- a/.github/workflows/delete-test-mirror-pr.yml
+++ b/.github/workflows/delete-test-mirror-pr.yml
@@ -60,7 +60,6 @@ jobs:
             exit 1
           fi
           git commit -m "chore: Remove dd-trace-java-docker-build test images for PR #${PR_NUMBER}"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         working-directory: images
 
       - name: Push changes
@@ -72,7 +71,6 @@ jobs:
           head-sha: "${{ steps.images-head.outputs.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
           working-directory: images
 
       - name: Create pull request

--- a/.github/workflows/update-mirror-digests.yml
+++ b/.github/workflows/update-mirror-digests.yml
@@ -90,7 +90,6 @@ jobs:
           fi
           git commit -m "chore: Update dd-trace-java-docker-build ci-* image digests"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         working-directory: images
 
       - name: Push changes
@@ -103,7 +102,6 @@ jobs:
           head-sha: "${{ steps.images-head.outputs.sha }}"
           create-branch: true
           command: push
-          commits: "${{ steps.create-commit.outputs.commit }}"
           working-directory: images
 
       - name: Create pull request


### PR DESCRIPTION
Fix commit push Github Action workflows that broke in the latest major version of `DataDog/commit-headless`: https://github.com/DataDog/commit-headless/blob/main/CHANGELOG.md#breaking-changes

Example warning: https://github.com/DataDog/dd-trace-java-docker-build/actions/runs/26459620095