### PR TITLE
Add EA JDK 27 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=eclipse-temurin:11-jdk-noble /opt/java/openjdk /usr/lib/jvm/11
 COPY --from=eclipse-temurin:17-jdk-noble /opt/java/openjdk /usr/lib/jvm/17
 COPY --from=eclipse-temurin:21-jdk-noble /opt/java/openjdk /usr/lib/jvm/21
 COPY --from=eclipse-temurin:25-jdk-noble /opt/java/openjdk /usr/lib/jvm/25
-# Java 27 TODO: remove 26 and update 27 images after GA
+# Java 27 TODO: remove following two lines after GA
 COPY --from=eclipse-temurin:26-jdk-noble /opt/java/openjdk /usr/lib/jvm/26
 COPY --from=openjdk:27-ea-jdk-bookworm /usr/local/openjdk-27 /usr/lib/jvm/27
 COPY --from=temurin-latest /opt/java/openjdk /usr/lib/jvm/${LATEST_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,9 @@ COPY --from=eclipse-temurin:11-jdk-noble /opt/java/openjdk /usr/lib/jvm/11
 COPY --from=eclipse-temurin:17-jdk-noble /opt/java/openjdk /usr/lib/jvm/17
 COPY --from=eclipse-temurin:21-jdk-noble /opt/java/openjdk /usr/lib/jvm/21
 COPY --from=eclipse-temurin:25-jdk-noble /opt/java/openjdk /usr/lib/jvm/25
+# Java 27 TODO: remove 26 and update 27 images after GA
 COPY --from=eclipse-temurin:26-jdk-noble /opt/java/openjdk /usr/lib/jvm/26
+COPY --from=openjdk:27-ea-jdk-bookworm /usr/local/openjdk-27 /usr/lib/jvm/27
 COPY --from=temurin-latest /opt/java/openjdk /usr/lib/jvm/${LATEST_VERSION}
 
 COPY --from=azul/zulu-openjdk:8 /usr/lib/jvm/zulu8 /usr/lib/jvm/zulu8
@@ -128,6 +130,7 @@ COPY --from=all-jdk /usr/lib/jvm/17 /usr/lib/jvm/17
 COPY --from=all-jdk /usr/lib/jvm/21 /usr/lib/jvm/21
 COPY --from=all-jdk /usr/lib/jvm/25 /usr/lib/jvm/25
 COPY --from=all-jdk /usr/lib/jvm/26 /usr/lib/jvm/26
+COPY --from=all-jdk /usr/lib/jvm/27 /usr/lib/jvm/27
 COPY --from=all-jdk /usr/lib/jvm/${LATEST_VERSION} /usr/lib/jvm/${LATEST_VERSION}
 
 # Base image with minimum requirements to build the project.
@@ -233,7 +236,9 @@ ENV JAVA_11_HOME=/usr/lib/jvm/11
 ENV JAVA_17_HOME=/usr/lib/jvm/17
 ENV JAVA_21_HOME=/usr/lib/jvm/21
 ENV JAVA_25_HOME=/usr/lib/jvm/25
+# Java 27 TODO: remove following two lines after GA
 ENV JAVA_26_HOME=/usr/lib/jvm/26
+ENV JAVA_27_HOME=/usr/lib/jvm/27
 ENV JAVA_${LATEST_VERSION}_HOME=/usr/lib/jvm/${LATEST_VERSION}
 
 ENV JAVA_HOME=${JAVA_8_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ COPY --from=all-jdk /usr/lib/jvm/11 /usr/lib/jvm/11
 COPY --from=all-jdk /usr/lib/jvm/17 /usr/lib/jvm/17
 COPY --from=all-jdk /usr/lib/jvm/21 /usr/lib/jvm/21
 COPY --from=all-jdk /usr/lib/jvm/25 /usr/lib/jvm/25
+# Java 27 TODO: remove following two lines after GA
 COPY --from=all-jdk /usr/lib/jvm/26 /usr/lib/jvm/26
 COPY --from=all-jdk /usr/lib/jvm/27 /usr/lib/jvm/27
 COPY --from=all-jdk /usr/lib/jvm/${LATEST_VERSION} /usr/lib/jvm/${LATEST_VERSION}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Image variants are available on a per JDK basis:
 - The `base` variant and its aliases — `8`, `11`, `17`, `21`, `25`, and `tip` — contain the base Eclipse Temurin JDK 8, 11, 17, 21, 25, and tip JDK version releases.
 - The `zulu8`, `zulu11`, `oracle8`, `ibm8`, `semeru8`, `semeru11`, `semeru17`, `graalvm17`, `graalvm21`, and `graalvm25` variants each contain the base JDKs in addition to the specific JDK from their name.
 - The `latest` variant contains the base JDKs and all of the specific JDKs above.
+- EA JDK `27` is currently being tested. <!-- Java 27 TODO: remove this line after GA -->
 
 All variants are published as multi-arch manifests covering `linux/amd64` and `linux/arm64`, so the same tag (e.g. `base`, `zulu8`, `tip`) resolves to the correct image for the host architecture.
 The `7` and `ibm8` variants are amd64-only because the upstream JDK images are not available for arm64;

--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -eu
 
 readonly IMAGE_NAME="ghcr.io/datadog/dd-trace-java-docker-build"
 
-readonly BASE_VARIANTS=(8 11 17 21 25 tip)
+readonly BASE_VARIANTS=(8 11 17 21 25 27 tip) # Java 27 TODO: move tip to 27 after GA
 
 readonly ALL_VARIANTS=(
     7
@@ -22,7 +22,7 @@ readonly ALL_VARIANTS=(
 # Variants whose upstream JDK images are not published for arm64.
 readonly AMD64_ONLY_VARIANTS=(7 ibm8)
 
-readonly LATEST_VERSION="26"
+readonly LATEST_VERSION="26" # Java 27 TODO: update to 27 after GA
 readonly PLATFORM="${PLATFORM:-linux/amd64}"
 readonly DIGESTS_DIR="${DIGESTS_DIR:-./digests}"
 
@@ -210,7 +210,8 @@ function do_inner_test() {
     "$JAVA_17_HOME/bin/java" -version
     "$JAVA_21_HOME/bin/java" -version
     "$JAVA_25_HOME/bin/java" -version
-    "$JAVA_26_HOME/bin/java" -version
+    "$JAVA_26_HOME/bin/java" -version # Java 27 TODO: delete after GA
+    "$JAVA_27_HOME/bin/java" -version # Java 27 TODO: delete after GA
     "${!java_latest_home}/bin/java" -version
     if [[ $variant != base && $variant != latest ]]; then
         if [[ $variant == "tip" ]]; then

--- a/build
+++ b/build
@@ -210,8 +210,9 @@ function do_inner_test() {
     "$JAVA_17_HOME/bin/java" -version
     "$JAVA_21_HOME/bin/java" -version
     "$JAVA_25_HOME/bin/java" -version
-    "$JAVA_26_HOME/bin/java" -version # Java 27 TODO: delete after GA
-    "$JAVA_27_HOME/bin/java" -version # Java 27 TODO: delete after GA
+    # Java 27 TODO: remove following two lines after GA
+    "$JAVA_26_HOME/bin/java" -version
+    "$JAVA_27_HOME/bin/java" -version
     "${!java_latest_home}/bin/java" -version
     if [[ $variant != base && $variant != latest ]]; then
         if [[ $variant == "tip" ]]; then

--- a/scripts/delete-test-mirror-entries.sh
+++ b/scripts/delete-test-mirror-entries.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 readonly SOURCE_PREFIX="ghcr.io/datadog/dd-trace-java-docker-build"
 readonly DEST_REPO="dd-trace-java-docker-build"
-readonly CI_VARIANTS=(base 7 8 11 17 21 25 tip zulu8 zulu11 oracle8 ibm8 semeru8 semeru11 semeru17 graalvm17 graalvm21 graalvm25)
+readonly CI_VARIANTS=(base 7 8 11 17 21 25 27 tip zulu8 zulu11 oracle8 ibm8 semeru8 semeru11 semeru17 graalvm17 graalvm21 graalvm25)
 
 if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
   echo "::error::PR_NUMBER must be numeric (got: '${PR_NUMBER}')" >&2

--- a/scripts/delete-test-mirror-entries.sh
+++ b/scripts/delete-test-mirror-entries.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 readonly SOURCE_PREFIX="ghcr.io/datadog/dd-trace-java-docker-build"
 readonly DEST_REPO="dd-trace-java-docker-build"
+# Java 27 TODO: move tip to 27 after GA
 readonly CI_VARIANTS=(base 7 8 11 17 21 25 27 tip zulu8 zulu11 oracle8 ibm8 semeru8 semeru11 semeru17 graalvm17 graalvm21 graalvm25)
 
 if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then

--- a/scripts/get-image-digests.sh
+++ b/scripts/get-image-digests.sh
@@ -10,6 +10,7 @@
 
 set -euo pipefail
 
+# Java 27 TODO: move tip to 27 after GA
 readonly CI_VARIANTS=(base 7 8 11 17 21 25 27 tip zulu8 zulu11 oracle8 ibm8 semeru8 semeru11 semeru17 graalvm17 graalvm21 graalvm25)
 
 # update_digest TAG DIGEST FILE

--- a/scripts/get-image-digests.sh
+++ b/scripts/get-image-digests.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-readonly CI_VARIANTS=(base 7 8 11 17 21 25 tip zulu8 zulu11 oracle8 ibm8 semeru8 semeru11 semeru17 graalvm17 graalvm21 graalvm25)
+readonly CI_VARIANTS=(base 7 8 11 17 21 25 27 tip zulu8 zulu11 oracle8 ibm8 semeru8 semeru11 semeru17 graalvm17 graalvm21 graalvm25)
 
 # update_digest TAG DIGEST FILE
 # Finds the line "source: ...:TAG" and updates the digest on the following line.


### PR DESCRIPTION
Use `openjdk` early access image for testing purposes only. Once the general release of JDK 27 is out (ETA September 2026), we will switch to `eclipse-temurin`.

Image tested in: https://github.com/DataDog/dd-trace-java/pull/11841