### PR TITLE
Checkout PR ref when creating mirror images

### DIFF
--- a/.github/workflows/create-test-mirror-pr.yml
+++ b/.github/workflows/create-test-mirror-pr.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: dd-trace-java-docker-build
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
       - name: Checkout DataDog/images
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/delete-test-mirror-pr.yml
+++ b/.github/workflows/delete-test-mirror-pr.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: dd-trace-java-docker-build
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
       - name: Checkout DataDog/images
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Checkout the repo at the inputted PR ref when creating mirror images. This ensures that new CI_VARIANTS included in the PR, e.g. for adding new JDK versions, are mirrored instead of using the `master` branch's CI_VARIANTS.