### PR TITLE
Remove PR ref from delete workflow

### DIFF
--- a/.github/workflows/delete-test-mirror-pr.yml
+++ b/.github/workflows/delete-test-mirror-pr.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: dd-trace-java-docker-build
-          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
       - name: Checkout DataDog/images
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Since README instructions recommend deleting the images after merge, the tested PR's changes will already be in `master` when we want to delete its test images.

Moreover, after the PR is merged, GitHub removes references to `refs/pull/${{ github.event.inputs.pr_number }}/merge`.

See: https://github.com/DataDog/dd-trace-java-docker-build/actions/runs/28878825640/job/85661134146