### PR TITLE
Update workflow to account for new entry

### DIFF
--- a/.github/workflows/update-mirror-digests.yml
+++ b/.github/workflows/update-mirror-digests.yml
@@ -69,7 +69,7 @@ jobs:
           echo "::error::Timeout after 30 minutes: ci-base digest did not change from existing mirror"
           exit 1
 
-      - name: Resolve digests and update mirror.lock.yaml files
+      - name: Resolve digests and update mirror files
         run: bash "${GITHUB_WORKSPACE}/dd-trace-java-docker-build/scripts/update-ci-image-digests.sh"
         working-directory: images
 
@@ -82,7 +82,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add mirror.lock.yaml
+          git add mirror.yaml mirror.lock.yaml
           if git diff --cached --quiet; then
             echo "No changes detected in mirror files; skipping commit."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/scripts/update-ci-image-digests.sh
+++ b/scripts/update-ci-image-digests.sh
@@ -10,27 +10,37 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SOURCE_PREFIX="ghcr.io/datadog/dd-trace-java-docker-build"
 readonly DEST_REPO="dd-trace-java-docker-build"
 
-is_amd64_only_variant() {
-  [[ "$1" == "7" || "$1" == "ibm8" ]]
-}
+insert_mirror_yaml_entry() {
+  local variant="$1" tag="ci-${variant}" amd64_only="false"
 
-append_mirror_yaml_entry() {
-  local variant="$1" tag="ci-${variant}"
+  if [[ "${variant}" == "7" || "${variant}" == "ibm8" ]]; then
+    amd64_only="true"
+  fi
 
-  {
-    printf '  - source: "%s:%s"\n' "${SOURCE_PREFIX}" "${tag}"
-    printf '    dest:\n'
-    printf '      repo: "%s"\n' "${DEST_REPO}"
-    printf '      tag: "%s"\n' "${tag}"
-    printf '    replication_target: ""\n'
-    printf '    platforms:\n'
-    printf '      - "linux/amd64"\n'
-    if ! is_amd64_only_variant "${variant}"; then
-      printf '      - "linux/arm64"\n'
-    fi
-    printf '    renovate:\n'
-    printf '      enabled: true\n'
-  } >> mirror.yaml
+  awk -v source_prefix="${SOURCE_PREFIX}" -v dest_repo="${DEST_REPO}" -v tag="${tag}" -v amd64_only="${amd64_only}" '
+    /^image_groups:$/ && !inserted {
+      print "  - source: \"" source_prefix ":" tag "\""
+      print "    dest:"
+      print "      repo: \"" dest_repo "\""
+      print "      tag: \"" tag "\""
+      print "    replication_target: \"\""
+      print "    platforms:"
+      print "      - \"linux/amd64\""
+      if (amd64_only != "true") {
+        print "      - \"linux/arm64\""
+      }
+      print "    renovate:"
+      print "      enabled: true"
+      inserted = 1
+    }
+    { print }
+    END {
+      if (!inserted) {
+        print "missing top-level image_groups section in mirror.yaml" > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' mirror.yaml > mirror.yaml.tmp && mv mirror.yaml.tmp mirror.yaml
 }
 
 append_mirror_lock_entry() {
@@ -49,7 +59,7 @@ for variant in "${CI_VARIANTS[@]}"; do
   source="${SOURCE_PREFIX}:${tag}"
 
   if ! grep -qF "${source}" mirror.yaml; then
-    append_mirror_yaml_entry "${variant}"
+    insert_mirror_yaml_entry "${variant}"
     echo "Added mirror.yaml entry: ${tag}"
   fi
 
@@ -57,7 +67,10 @@ for variant in "${CI_VARIANTS[@]}"; do
     append_mirror_lock_entry "${tag}" "${DIGESTS[$variant]}"
     echo "Added mirror.lock.yaml entry: ${tag}"
   fi
+done
 
+for variant in "${CI_VARIANTS[@]}"; do
+  tag="ci-${variant}"
   update_digest "${tag}" "${DIGESTS[$variant]}" mirror.lock.yaml
   echo "Updated mirror.lock.yaml: ${tag}"
 done

--- a/scripts/update-ci-image-digests.sh
+++ b/scripts/update-ci-image-digests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# update-ci-image-digests.sh — update pinned ci-* image digests in mirror.lock.yaml in the DataDog/images repo.
+# update-ci-image-digests.sh - add/update ci-* image mirror entries in the DataDog/images repo.
 #
 # This script is called in the update-mirror-digests Github workflow.
 # It must be run from the root of DataDog/images and requires crane to be installed.
@@ -7,23 +7,57 @@
 set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SOURCE_PREFIX="ghcr.io/datadog/dd-trace-java-docker-build"
+readonly DEST_REPO="dd-trace-java-docker-build"
 
-# Verify all ci-* entries exist before updating
-PREFIX="ci-"
+is_amd64_only_variant() {
+  [[ "$1" == "7" || "$1" == "ibm8" ]]
+}
+
+append_mirror_yaml_entry() {
+  local variant="$1" tag="ci-${variant}"
+
+  {
+    printf '  - source: "%s:%s"\n' "${SOURCE_PREFIX}" "${tag}"
+    printf '    dest:\n'
+    printf '      repo: "%s"\n' "${DEST_REPO}"
+    printf '      tag: "%s"\n' "${tag}"
+    printf '    replication_target: ""\n'
+    printf '    platforms:\n'
+    printf '      - "linux/amd64"\n'
+    if ! is_amd64_only_variant "${variant}"; then
+      printf '      - "linux/arm64"\n'
+    fi
+    printf '    renovate:\n'
+    printf '      enabled: true\n'
+  } >> mirror.yaml
+}
+
+append_mirror_lock_entry() {
+  local tag="$1" digest="$2"
+
+  printf '    # renovate\n    - source: %s:%s\n      digest: %s\n' \
+    "${SOURCE_PREFIX}" "${tag}" "${digest}" >> mirror.lock.yaml
+}
+
+readonly PREFIX="ci-"
 # shellcheck source=scripts/get-image-digests.sh
 source "${SCRIPT_DIR}/get-image-digests.sh"
 
 for variant in "${CI_VARIANTS[@]}"; do
-  if ! grep -qF "ghcr.io/datadog/dd-trace-java-docker-build:ci-${variant}" mirror.lock.yaml; then
-    echo "::error::Missing from mirror.lock.yaml: ci-${variant}" >&2
-    echo "Bootstrap ci-* entries manually before running this workflow." >&2
-    exit 1
-  fi
-done
-
-# Update existing digest entries in mirror.lock.yaml in-place
-for variant in "${CI_VARIANTS[@]}"; do
   tag="ci-${variant}"
+  source="${SOURCE_PREFIX}:${tag}"
+
+  if ! grep -qF "${source}" mirror.yaml; then
+    append_mirror_yaml_entry "${variant}"
+    echo "Added mirror.yaml entry: ${tag}"
+  fi
+
+  if ! grep -qF "${source}" mirror.lock.yaml; then
+    append_mirror_lock_entry "${tag}" "${DIGESTS[$variant]}"
+    echo "Added mirror.lock.yaml entry: ${tag}"
+  fi
+
   update_digest "${tag}" "${DIGESTS[$variant]}" mirror.lock.yaml
   echo "Updated mirror.lock.yaml: ${tag}"
 done


### PR DESCRIPTION
Update the "Update mirror digests" workflow to account for new entries.

For example, this is the case when we want to add a new entry for a EA JDK version that hasn't been promoted to "tip" yet. See: https://github.com/DataDog/dd-trace-java-docker-build/actions/runs/28883773542/job/85678556199