### PR TITLE
Ensure new entry is inserted at end of ci- groups

### DIFF
--- a/scripts/update-ci-image-digests.sh
+++ b/scripts/update-ci-image-digests.sh
@@ -10,44 +10,99 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SOURCE_PREFIX="ghcr.io/datadog/dd-trace-java-docker-build"
 readonly DEST_REPO="dd-trace-java-docker-build"
 
-insert_mirror_yaml_entry() {
-  local variant="$1" tag="ci-${variant}" amd64_only="false"
-
-  if [[ "${variant}" == "7" || "${variant}" == "ibm8" ]]; then
-    amd64_only="true"
-  fi
-
-  awk -v source_prefix="${SOURCE_PREFIX}" -v dest_repo="${DEST_REPO}" -v tag="${tag}" -v amd64_only="${amd64_only}" '
-    /^image_groups:$/ && !inserted {
-      print "  - source: \"" source_prefix ":" tag "\""
-      print "    dest:"
-      print "      repo: \"" dest_repo "\""
-      print "      tag: \"" tag "\""
-      print "    replication_target: \"\""
-      print "    platforms:"
-      print "      - \"linux/amd64\""
-      if (amd64_only != "true") {
-        print "      - \"linux/arm64\""
-      }
-      print "    renovate:"
-      print "      enabled: true"
-      inserted = 1
-    }
-    { print }
-    END {
-      if (!inserted) {
-        print "missing top-level image_groups section in mirror.yaml" > "/dev/stderr"
-        exit 1
-      }
-    }
-  ' mirror.yaml > mirror.yaml.tmp && mv mirror.yaml.tmp mirror.yaml
+is_amd64_only_variant() {
+  [[ "$1" == "7" || "$1" == "ibm8" ]]
 }
 
-append_mirror_lock_entry() {
-  local tag="$1" digest="$2"
+insert_entry_after_last_ci_block() {
+  local file="$1" ci_line_prefix="$2" next_block_regex="$3" entry_file="$4"
+
+  awk -v file="${file}" -v ci_line_prefix="${ci_line_prefix}" -v next_block_regex="${next_block_regex}" -v entry_file="${entry_file}" '
+    function print_entry(line) {
+      while ((getline line < entry_file) > 0) {
+        print line
+      }
+      close(entry_file)
+    }
+    { lines[NR] = $0 }
+    END {
+      for (i = 1; i <= NR; i++) {
+        if (index(lines[i], ci_line_prefix) == 1) {
+          last_ci = i
+        }
+      }
+      if (!last_ci) {
+        print "missing dd-trace-java-docker-build ci-* section in " file > "/dev/stderr"
+        exit 1
+      }
+      insert_at = NR + 1
+      for (i = last_ci + 1; i <= NR; i++) {
+        if (lines[i] ~ next_block_regex) {
+          insert_at = i
+          break
+        }
+      }
+      for (i = 1; i <= NR; i++) {
+        if (i == insert_at) {
+          print_entry()
+        }
+        print lines[i]
+      }
+      if (insert_at == NR + 1) {
+        print_entry()
+      }
+    }
+  ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
+}
+
+write_mirror_yaml_entry() {
+  local file="$1" variant="$2" tag="ci-${variant}"
+
+  {
+    printf '  - source: "%s:%s"\n' "${SOURCE_PREFIX}" "${tag}"
+    printf '    dest:\n'
+    printf '      repo: "%s"\n' "${DEST_REPO}"
+    printf '      tag: "%s"\n' "${tag}"
+    printf '    replication_target: ""\n'
+    printf '    platforms:\n'
+    printf '      - "linux/amd64"\n'
+    if ! is_amd64_only_variant "${variant}"; then
+      printf '      - "linux/arm64"\n'
+    fi
+    printf '    renovate:\n'
+    printf '      enabled: true\n'
+  } > "${file}"
+}
+
+write_mirror_lock_entry() {
+  local file="$1" tag="$2" digest="$3"
 
   printf '    # renovate\n    - source: %s:%s\n      digest: %s\n' \
-    "${SOURCE_PREFIX}" "${tag}" "${digest}" >> mirror.lock.yaml
+    "${SOURCE_PREFIX}" "${tag}" "${digest}" > "${file}"
+}
+
+insert_mirror_yaml_entry() {
+  local variant="$1" entry_file
+
+  entry_file="$(mktemp)"
+  write_mirror_yaml_entry "${entry_file}" "${variant}"
+  if ! insert_entry_after_last_ci_block mirror.yaml "  - source: \"${SOURCE_PREFIX}:ci-" '^(  (#|- source:)|image_groups:)' "${entry_file}"; then
+    rm -f "${entry_file}"
+    return 1
+  fi
+  rm -f "${entry_file}"
+}
+
+insert_mirror_lock_entry() {
+  local tag="$1" digest="$2" entry_file
+
+  entry_file="$(mktemp)"
+  write_mirror_lock_entry "${entry_file}" "${tag}" "${digest}"
+  if ! insert_entry_after_last_ci_block mirror.lock.yaml "    - source: ${SOURCE_PREFIX}:ci-" '^    (# renovate|- source:)' "${entry_file}"; then
+    rm -f "${entry_file}"
+    return 1
+  fi
+  rm -f "${entry_file}"
 }
 
 readonly PREFIX="ci-"
@@ -64,7 +119,7 @@ for variant in "${CI_VARIANTS[@]}"; do
   fi
 
   if ! grep -qF "${source}" mirror.lock.yaml; then
-    append_mirror_lock_entry "${tag}" "${DIGESTS[$variant]}"
+    insert_mirror_lock_entry "${tag}" "${DIGESTS[$variant]}"
     echo "Added mirror.lock.yaml entry: ${tag}"
   fi
 done


### PR DESCRIPTION
Follow-up of #171  that ensures the new entry, if it exists, is inserted at the end of the existing `ci-` groups in the mirror files of the `images` repo.

This script was tested on a local copy of the `images` repo.