### PR TITLE
Trust Datadog CA certs in OS and all JDK truststores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG LATEST_VERSION
 ARG ALL_JDK_STAGE=all-jdk-amd64
 ARG FULL_STAGE=full-amd64
 FROM eclipse-temurin:${LATEST_VERSION}-jdk-noble AS temurin-latest
+FROM registry.ddbuild.io/images/datadog-ca-certs:standard AS datadog-ca-certs
 
 # Intermediate image used to prune cruft from JDKs and squash them all.
 FROM ubuntu:24.04 AS all-jdk-common
@@ -51,6 +52,14 @@ RUN <<-EOT
 
 	sudo apt-get clean
 	sudo rm -rf /var/lib/apt/lists/*
+EOT
+
+# Stage the Datadog CA certs and import script, and trust the certs at the OS level.
+COPY --from=datadog-ca-certs /certs/datadog /usr/local/share/ca-certificates/datadog
+COPY scripts/import-datadog-certs.sh /usr/local/bin/import-datadog-certs.sh
+RUN <<-EOT
+	set -eux
+	sudo update-ca-certificates
 EOT
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -95,6 +104,9 @@ RUN --mount=type=secret,id=oracle_java8_token,uid=1001,gid=1001,mode=0400 <<-EOT
 	unset ORACLE_JAVA8_TOKEN
 EOT
 
+# Import the Datadog CA certs into every JDK's own cacerts truststore.
+RUN sudo /usr/local/bin/import-datadog-certs.sh /usr/lib/jvm
+
 # Remove cruft from JDKs that is not used in the build process.
 RUN <<-EOT
 	sudo rm -rf \
@@ -111,6 +123,9 @@ FROM --platform=linux/amd64 ibmjava:8-sdk AS ibm8-amd64
 FROM all-jdk-common AS all-jdk-amd64
 COPY --from=zulu7-amd64 /usr/lib/jvm/zulu7 /usr/lib/jvm/7
 COPY --from=ibm8-amd64 /opt/ibm/java /usr/lib/jvm/ibm8
+
+# Import the Datadog CA certs into the amd64-only ibm8 truststore.
+RUN sudo /usr/local/bin/import-datadog-certs.sh /usr/lib/jvm/ibm8
 
 RUN <<-EOT
 	sudo rm -rf \

--- a/scripts/import-datadog-certs.sh
+++ b/scripts/import-datadog-certs.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Import the Datadog CA certificates into the truststore of every JDK
+# found under the given search roots (passed as arguments).
+set -eux
+
+DD_CERTS_DIR=/usr/local/share/ca-certificates/datadog
+
+# Truststore path pattern compatible with both legacy (JDK 8) and modern JDKs.
+JDK_TRUSTSTORE_PATH='*/lib/security/cacerts'
+
+for truststore in $(find -L "$@" -path "${JDK_TRUSTSTORE_PATH}" -type f | sort); do
+	java_home="${truststore%/lib/security/cacerts}"
+	java_home="${java_home%/jre}"
+	keytool="${java_home}/bin/keytool"
+	[ -x "${keytool}" ] || continue
+	for cert in $(find "${DD_CERTS_DIR}" -type f -name '*.crt' | sort); do
+		alias="datadog-$(basename "${cert}" .crt)"
+		if "${keytool}" -list -storepass changeit -keystore "${truststore}" -alias "${alias}" >/dev/null 2>&1; then
+			"${keytool}" -delete -storepass changeit -keystore "${truststore}" -alias "${alias}"
+		fi
+		"${keytool}" -importcert -noprompt -trustcacerts -storepass changeit -keystore "${truststore}" -alias "${alias}" -file "${cert}"
+	done
+done


### PR DESCRIPTION
# What Does This Do

Adds the Datadog CA certificates to the build image so outbound TLS to Datadog-internal endpoints is trusted:

- Pulls certs from `registry.ddbuild.io/images/datadog-ca-certs:standard`.
- Trusts them at the OS level via `update-ca-certificates`.
- Adds a new `scripts/import-datadog-certs.sh` that imports the certs into every JDK's own `cacerts` truststore (including the `jre/lib/security/cacerts` layout used by JDK 8 and the amd64-only `ibm8` JDK).

# Motivation

Instead of querying MASS like `https://mass-read.us1.ddbuild.io`(often failed with `503` error), use more reliable `https://mass-read.rapid-dependency-management-mass.all-clusters.local-dc.fabric.dog:8443` (recommended by infra team).

JDKs ship their own `cacerts` and do not consult `/etc/ssl/certs/java/cacerts`, so trusting the certs at the OS level alone is not enough. Java processes running in the image need the Datadog CAs in each JDK truststore to establish TLS to Datadog-internal services.

# Additional Notes

The import script runs as `root` via `sudo` because the JDKs are `COPY`'d from other stages and owned by root. Existing `datadog-*` aliases are deleted and re-imported to keep the operation idempotent.